### PR TITLE
Ensure moduleAddedLate receives correct arguments in DescendantAdded

### DIFF
--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -72,13 +72,13 @@ function SocialHandler:GetTotalFriendPlaytime(player : Player) : number
         return 0
     end
 
-    if #cachedData.Friends  > 0 then
+    FriendsInServerCache[player] = nil
+
+    if #cachedData.Friends > 0 then
         return cachedData.TotalTime + (tick() - cachedData.Timestamp)
     else
         return cachedData.TotalTime
     end
-
-    FriendsInServerCache[player] = nil
 end
 
 --= Initializers =--
@@ -93,8 +93,8 @@ function SocialHandler:Init()
             }, { player = player })
         end
 
-
-        -- Look for friends
+        --NOTE: Disabled since large servers with lots of players joining will result in too many HTTP requests.
+        --[[ Look for friends
         for _, potentialFriend in ipairs(Players:GetPlayers()) do
             if potentialFriend ~= player and (player:IsFriendsWith(potentialFriend.UserId) or player.UserId < 0) then
                 FriendStatusUpdated(player, potentialFriend, true)
@@ -114,7 +114,7 @@ function SocialHandler:Init()
                 friendUserId = cachedData.Friends[1].UserId,
                 friendsInServer = #cachedData.Friends,
             }, { player = player })
-        end
+        end]]
     end
 
     Players.PlayerAdded:Connect(playerAdded)

--- a/src/init.lua
+++ b/src/init.lua
@@ -10,6 +10,7 @@
 --]]
 
 --= Root =--
+
 local Gamebeast = { }
 
 --= Roblox Services =--
@@ -230,7 +231,6 @@ function Gamebeast:Setup(setupConfig : ServerSetupConfig?)
 	dataCacheModule:Set("Key", setupConfig.key)
 	dataCacheModule:Set("Settings", sdkSettings)
 end
-
 
 --= Initializers =--
 do

--- a/src/init.lua
+++ b/src/init.lua
@@ -116,7 +116,9 @@ local function AddModuleFolder(modulesFolder : Instance)
 	end
 
 	modulesFolder.Modules.DescendantAdded:Connect(moduleAddedLate)
-	modulesFolder.Public.DescendantAdded:Connect(moduleAddedLate, true)
+	modulesFolder.Public.DescendantAdded:Connect(function(module : ModuleScript)
+		moduleAddedLate(module, true)
+	end)
 end
 
 local function FindModule(moduleCache : {[string] : ModuleData | PublicModuleData}, name : string, timeout : number?)


### PR DESCRIPTION
`modulesFolder.Public.DescendantAdded:Connect(moduleAddedLate, true)` does not work as intended as [Connect does not accept additional arguments.](https://create.roblox.com/docs/reference/engine/datatypes/RBXScriptSignal#Connect)

This pull request changes the behaviour of this connection to correctly pass `true` for 'public' if a public module is added late.