### PR TITLE
fix: max server report metric aggregations index

### DIFF
--- a/src/Infra/MetaData.lua
+++ b/src/Infra/MetaData.lua
@@ -1,5 +1,5 @@
 -- Contains version information for the SDK
 
 return {
-    version = "v0.4.0"
+    version = "v0.4.1"
 }

--- a/src/Infra/Server/Modules/ServerStateReporter.luau
+++ b/src/Infra/Server/Modules/ServerStateReporter.luau
@@ -66,11 +66,11 @@ local function AggregateMetric(metricHistory: {number})
         max = max,
         sum = sum,
         average = sum / #metricHistory,
-        median = metricHistory[math.floor(#metricHistory / 2)],
-        p25 = metricHistory[math.floor(#metricHistory * 0.25)],
-        p75 = metricHistory[math.floor(#metricHistory * 0.75)],
-        p90 = metricHistory[math.floor(#metricHistory * 0.90)],
-        p99 = metricHistory[math.floor(#metricHistory * 0.99)]
+        median = metricHistory[math.max(math.floor(#metricHistory / 2), 1)],
+        p25 = metricHistory[math.max(math.floor(#metricHistory * 0.25), 1)],
+        p75 = metricHistory[math.max(math.floor(#metricHistory * 0.75), 1)],
+        p90 = metricHistory[math.max(math.floor(#metricHistory * 0.90), 1)],
+        p99 = metricHistory[math.max(math.floor(#metricHistory * 0.99), 1)]
     }
 end
 


### PR DESCRIPTION
* addresses issue where small metric history arrays would produce aggregation values of < 1. Calling `math.floor` on those aggregations resulted in 0-indexes, sending incorrect values to the backend. This caused some server state reports to be rejected and output spam in Studio