### PR TITLE
v0.5.0

### DIFF
--- a/src/Infra/Client/Modules/ClientConfigs.lua
+++ b/src/Infra/Client/Modules/ClientConfigs.lua
@@ -75,10 +75,11 @@ function ClientConfigs:Get(path : string | { string }, _configs : any?)
 	
     local target = _configs or CachedConfigs
 	for _, key in path do
-        if not target[key] then
+        target = target[key]
+
+        if target == nil then
             return nil
         end
-        target = target[key]
     end
 
 	return target

--- a/src/Infra/Client/Modules/ClientInfoHandler.lua
+++ b/src/Infra/Client/Modules/ClientInfoHandler.lua
@@ -38,6 +38,8 @@ local ProductInfoCache = {} :: {[number] : {PriceInRobux : number}}
 local CurrentClientInfoCache = {} :: {[string] : any}
 local FriendCache = {} :: {[number] : boolean}
 local FriendsOnline = 0
+local PendingUpdate = false
+local CurrentInputType = nil
 
 --= Public Variables =--
 
@@ -46,7 +48,16 @@ local FriendsOnline = 0
 local function UpdateClientInfo(key : string, value : any, force : boolean?)
     if CurrentClientInfoCache[key] ~= value or force then
         CurrentClientInfoCache[key] = value
-        ClientInfoRemote:FireServer(key, value)
+
+        if PendingUpdate then
+            return
+        end
+
+        PendingUpdate = true
+        task.defer(function()
+            PendingUpdate = false
+            ClientInfoRemote:FireServer(CurrentClientInfoCache)
+        end)
     end
 end
 
@@ -74,25 +85,103 @@ local function UpdateFriendCache()
     UpdateClientInfo("friendsOnline", FriendsOnline)
 end
 
+local function DetermineInputTypeString(InputEnum) 
+    if InputEnum == Enum.UserInputType.Keyboard then
+        return "keyboard"
+    elseif InputEnum == Enum.UserInputType.Touch then
+        return "touch"
+    elseif string.match(tostring(InputEnum),"Gamepad") then
+        return "gamepad"
+    end
+end
+
 --= API Functions =--
 
-function ClientInfoHandler:GetDeviceType() : string
+function ClientInfoHandler:GetDeviceType() : (string, string)
+    -- Determine device type
+    local deviceType = "unknown"
     if UserInputService.VREnabled or VRService.VREnabled then
-        return "vr"
+        deviceType = "vr"
     elseif UserInputService.TouchEnabled and not UserInputService.KeyboardEnabled then
-		return "mobile"
+		deviceType = "mobile"
 	elseif UserInputService.GamepadEnabled and not UserInputService.KeyboardEnabled then
-		return "console"
+		deviceType = "console"
 	elseif UserInputService.KeyboardEnabled then
-		return "pc"
-	else
-		return "unknown"
+		deviceType = "pc"
 	end
+
+    -- Determine device subtype
+    local deviceSubType = "unknown"
+    if deviceType == "mobile" then
+        local camera = workspace.CurrentCamera
+        if camera then
+            local longestSide = math.max(camera.ViewportSize.X, camera.ViewportSize.Y)
+            local shortestSide = math.min(camera.ViewportSize.X, camera.ViewportSize.Y)
+            local aspectRatio = longestSide / shortestSide
+            if aspectRatio > 1.8 then
+                deviceSubType = "phone"
+            elseif aspectRatio <= 1.7 then
+                deviceSubType = "tablet"
+            else -- Devices in this range can be either phone or tablet equally. Older devices share the 16:9 aspect ratio.
+                deviceSubType = "phone" -- We'll assume phone for now, since phone users are more common.
+            end
+        end
+    elseif deviceType == "console" then
+        local imageUrl = UserInputService:GetImageForKeyCode(Enum.KeyCode.ButtonX)
+        if string.find(imageUrl, "Xbox") then
+            deviceSubType = "xbox"
+        elseif string.find(imageUrl, "PlayStation") then
+            deviceSubType = "playstation"
+        else
+            deviceSubType = "unknown"
+        end
+    elseif deviceType == "vr" then
+        deviceSubType = "unknown" -- No reliable way to determine VR headset type in Roblox.
+    elseif deviceType == "pc" then
+        deviceSubType = "unknown" -- No reliable way to determine PC type in Roblox
+    end
+
+    return deviceType, deviceSubType
 end
+
+
 
 --= Initializers =--
 function ClientInfoHandler:Init()
-    UpdateClientInfo("device", self:GetDeviceType(), true)
+    local deviceType, deviceSubType = self:GetDeviceType()
+    UpdateClientInfo("deviceSubType", deviceSubType)
+    UpdateClientInfo("device", deviceType, true)
+
+    -- Input type detection
+
+    local function inputTypeChanged(inputType : string)
+        if CurrentInputType ~= inputType then
+            CurrentInputType = inputType
+            UpdateClientInfo("inputType", CurrentInputType)
+        end
+    end
+
+    if UserInputService.GamepadEnabled then
+        inputTypeChanged("gamepad")
+    elseif UserInputService.TouchEnabled then
+        inputTypeChanged("touch")
+    else
+        inputTypeChanged("keyboard")
+    end
+
+    --// Detect CurrentInputType changes from 'LastInputType'
+    UserInputService.LastInputTypeChanged:Connect(function(lastType)
+        local newType = DetermineInputTypeString(lastType)
+        if newType and newType ~= CurrentInputType then
+            inputTypeChanged(newType)
+        end
+    end)
+
+     UserInputService.InputChanged:Connect(function(InputObject)
+        if InputObject.UserInputType == Enum.UserInputType.MouseMovement then
+            inputTypeChanged("keyboard")
+        end
+    end)
 
     -- Friends online
     task.spawn(function()

--- a/src/Infra/MetaData.lua
+++ b/src/Infra/MetaData.lua
@@ -1,5 +1,5 @@
 -- Contains version information for the SDK
 
 return {
-    version = "v0.4.0"
+    version = "v0.4.1"
 }

--- a/src/Infra/MetaData.lua
+++ b/src/Infra/MetaData.lua
@@ -1,5 +1,5 @@
 -- Contains version information for the SDK
 
 return {
-    version = "v0.4.1"
+    version = "v0.5.0"
 }

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -154,6 +154,8 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		["value"] = value,
 		["properties"] = {
 			["sdkPlatform"] = "roblox",
+			["placeId"] = game.PlaceId,
+			["placeVersion"] = game.PlaceVersion,
 			["origin"] = source,
 			["device"] = nil, -- Resolved later
 			["deviceSubType"] = nil, -- Resolved later

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -20,6 +20,8 @@ local RunService = game:GetService("RunService")
 
 --= Dependencies =--
 
+local Timer = shared.GBMod("Timer") ---@module Timer
+local Cleaner = shared.GBMod("Cleaner")
 local MetaData = shared.GBMod("MetaData")
 local GetRemote = shared.GBMod("GetRemote")
 local Utilities = shared.GBMod("Utilities")
@@ -27,7 +29,7 @@ local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local LocalizationCache = shared.GBMod("LocalizationCache") ---@module LocalizationCache
 local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
-
+local Experiments = shared.GBMod("Experiments") ---@module Experiments
 
 --= Types =--
 
@@ -59,22 +61,6 @@ local MarkerQueue = {}
 local SessionIds = {}
 local LastEventReportTime = 0
 local ClientInfoWarned = false
-
---[[
-	When set, this is included in each marker's `experimentGroupId` property.
-
-	Set through `EngagementMarkers:SetServerExperimentGroupId()` based on the
-	group ID currently assigned to the server in an experiment, if any.
-]]
-local GameserverExperimentGroupId = nil :: number?
-
---[[
-	When set, these are included in the `experimentGroupId` property of the player's markers.
-
-	Set through `EngagementMarkers:SetPlayerExperimentGroupId()` based on the
-	group ID currently assigned to the player in an experiment, if any.
-]]
-local ExperimentGroupIdByPlayer = {} :: {[Player]: number}
 
 
 --= Public Variables =--
@@ -174,8 +160,8 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 			["language"] = player and LocalizationCache:GetLocaleId(player) or nil,
 			["country"] = player and LocalizationCache:GetRegionId(player) or nil,
 			["experimentGroupId"] = player
-				and ExperimentGroupIdByPlayer[player]
-				or GameserverExperimentGroupId,
+				and Experiments.AssignedGroupIdByPlayer[player]
+				or Experiments.AssignedServerGroupId,
 		},
 	}
 
@@ -187,41 +173,93 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 			EngagementMarkers:SendMarkers()
 		end
 	end
-	
-	if player then -- Ensure marker gets fired with device info on timeout or bind to close
-		local function resolved()
+
+	--[[
+		Ensure markers are sent with all required data.
+	]]
+
+	local pendingMarkerData = {
+		pendingCleaner = Cleaner.new(),
+		tasks = {},
+		activeTasks = 0,
+		resolved = nil,
+	}
+
+	InternalConfigs:OnReady(function()
+		local function resolved(shutdown : boolean?)
+			pendingMarkerData.pendingCleaner:Clean()
+
+			-- Add any final missing data to the marker
 			entry.properties.device = ServerClientInfoHandler:GetClientInfo(player, "device")
 			addMarker()
-		end
-		
-		local waitingData = {
-			callback = resolved,
-			connection = nil
-		}
 
-		local connection = ServerClientInfoHandler:OnClientInfoResolved(player, CLIENT_DATA_TIMEOUT, function(timedout, ...)
-			if timedout and ClientInfoWarned == false then
+			-- Remove from waiting list if it exists
+			if not shutdown then
+				local index = table.find(WaitingPlayerMarkers, pendingMarkerData)
+				if index then
+					table.remove(WaitingPlayerMarkers, index)
+				end
+			end
+		end
+
+		pendingMarkerData.resolved = resolved
+
+		-- Task manager
+
+		-- Will only add tasks if they arent already finished and the connection is still active.
+		local function addTask(taskName : string, connection : RBXScriptConnection?)
+			if not pendingMarkerData.tasks[taskName] and connection ~= nil and connection.Connected == true then
+				pendingMarkerData.activeTasks += 1
+				pendingMarkerData.tasks[taskName] = connection
+
+				if connection then
+					pendingMarkerData.pendingCleaner:Add(connection)
+				end
+			end
+		end
+
+		local function completeTask(taskName : string)
+			if pendingMarkerData.tasks[taskName] then
+				pendingMarkerData.tasks[taskName] = nil
+				pendingMarkerData.activeTasks -= 1
+
+				if pendingMarkerData.activeTasks <= 0 then
+					resolved()
+				end
+			end
+		end
+
+		-- Stop wating after some time if tasks are not resolved
+		local dataFetchTimer = Timer.new(CLIENT_DATA_TIMEOUT)
+		pendingMarkerData.pendingCleaner:Add(dataFetchTimer)
+		pendingMarkerData.pendingCleaner:Add(dataFetchTimer:OnEnd(function()
+			if not ServerClientInfoHandler:IsClientInfoResolved(player) and ClientInfoWarned == false then
 				Utilities.GBWarn("Failed to resolve client info, did you forget to :Setup() Gamebeast SDK on the client?")
 				ClientInfoWarned = true
 			end
 
-			local index = table.find(WaitingPlayerMarkers, waitingData)
-			if index then
-				table.remove(WaitingPlayerMarkers, index)
-			end
-
 			resolved()
-		end)
+		end))
 
-		if not connection then
-			return
+		if player then -- Ensure marker gets fired with device info on timeout or bind to close
+			addTask("clientInfo", ServerClientInfoHandler:OnClientInfoResolved(player, function()
+				completeTask("clientInfo")
+			end))
 		end
 
-		waitingData.connection = connection
-		table.insert(WaitingPlayerMarkers, waitingData)
-	else
-		addMarker()
-	end
+		if entry.properties.experimentGroupId == nil then
+			addTask("experimentGroup", Experiments:ListenForPlayerAssignment(player, function (groupId: number?)
+				entry.properties.experimentGroupId = groupId
+				completeTask("experimentGroup")
+			end))
+		end
+
+		if pendingMarkerData.activeTasks <= 0 then
+			resolved()
+		else
+			table.insert(WaitingPlayerMarkers, pendingMarkerData)
+		end
+	end)
 end
 
 -- Fire an engagement marker. Used by devs via API module, wraps createMarker to declare source.
@@ -237,22 +275,6 @@ end
 
 function EngagementMarkers:ClearSessionId(player : Player)
 	SessionIds[player] = nil
-end
-
---[[
-	Sets the assigned experiment group ID to be included in the `experimentGroupId`
-	property of the player's markers.
-]]
-function EngagementMarkers:SetPlayerExperimentGroupId(player: Player, groupId: number?)
-	ExperimentGroupIdByPlayer[player] = groupId
-end
-
---[[
-	Sets the assigned experiment group ID to be included in the `experimentGroupId`
-	property of the server's markers.
-]]
-function EngagementMarkers:SetServerExperimentGroupId(groupId: number?)
-	GameserverExperimentGroupId = groupId
 end
 
 --= Initializers =--
@@ -292,9 +314,8 @@ function EngagementMarkers:Init()
 	end)
 
 	GBRequests:OnFinalRequestCall(function()
-		for _, waiting in WaitingPlayerMarkers do
-			waiting.connection:Disconnect()
-			waiting.callback()
+		for _, data in WaitingPlayerMarkers do
+			data.resolved(true)
 		end
 
 		EngagementMarkers:SendMarkers()

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -156,6 +156,8 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 			["sdkPlatform"] = "roblox",
 			["origin"] = source,
 			["device"] = nil, -- Resolved later
+			["deviceSubType"] = nil, -- Resolved later
+			["inputType"] = nil, -- Resolved later
 			["position"] = position ~= nil and EncodeVector3(position) or nil,
 			["language"] = player and LocalizationCache:GetLocaleId(player) or nil,
 			["country"] = player and LocalizationCache:GetRegionId(player) or nil,
@@ -191,6 +193,8 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 
 			-- Add any final missing data to the marker
 			entry.properties.device = ServerClientInfoHandler:GetClientInfo(player, "device")
+			entry.properties.deviceSubType = ServerClientInfoHandler:GetClientInfo(player, "deviceSubType")
+			entry.properties.inputType = ServerClientInfoHandler:GetClientInfo(player, "inputType")
 			addMarker()
 
 			-- Remove from waiting list if it exists

--- a/src/Infra/Server/Modules/Experiments.luau
+++ b/src/Infra/Server/Modules/Experiments.luau
@@ -29,9 +29,26 @@ type AvailableExperimentsSnapshot = {
 	scheduled: {[string]: {number}},
 }
 type ExperimentReassignmentPropagationRequest = {
-	playerIds: {number},
+	playerIds: {string},
 	gameserverIds: {string},
 }
+
+type BaseAssignmentResponse = {
+	groups: {AvailableExperimentGroupSnapshot}?,
+}
+type GameserverAssignmentResponse = BaseAssignmentResponse & {
+	targetType: "gameserver",
+	gameserverGroupId: number?,
+}
+type PlayerAssignmentResponse = BaseAssignmentResponse & {
+	targetType: "player",
+	playerIdsByGroupId: {[string]: {string}},
+}
+type EmptyAssignmentResponse = nil
+type AssignmentResponse =
+	| GameserverAssignmentResponse
+	| PlayerAssignmentResponse
+	| EmptyAssignmentResponse
 
 --[[
 	How long to wait before requesting bulk assignment after calling `queueAssignment()`.
@@ -224,8 +241,9 @@ function Experiments:ProcessExperimentReassignmentRequest(request: ExperimentRea
 	end
 
 	-- If players in the server are included in the request, queue them for reassignment
-	for _, playerId in request.playerIds do
-		local player = Players:GetPlayerByUserId(playerId)
+	for _, playerIdString in request.playerIds do
+		local playerId = tonumber(playerIdString)
+		local player = playerId and Players:GetPlayerByUserId(playerId)
 		if player then
 			Utilities.GBLog("Queueing reassignment as requested for player:", player.Name)
 			queueAssignment({ player })
@@ -377,34 +395,36 @@ function executeAssignmentRequest()
 
 		return
 	end
+	local assignmentResponse = response :: AssignmentResponse
 
 	-- If no experiments are available for assignment, disable assignment
-	if not response then
+	if not assignmentResponse then
 		disableAssignment()
 		return
 	end
 
 	-- Cache new received group snapshots
-	if response.groups then
-		for _, group in response.groups do
+	if assignmentResponse.groups then
+		for _, group in assignmentResponse.groups do
 			initializeActiveGroupState(group)
 			clearUnfetchedActiveGroupState(group.id)
 		end
 	end
 
-	if response.gameserverGroupId then
-		setAssignedServerGroupId(response.gameserverGroupId)
+	if (assignmentResponse.targetType == "gameserver") and assignmentResponse.gameserverGroupId then
+		setAssignedServerGroupId(assignmentResponse.gameserverGroupId)
 
 		-- Clear previous per-player assignments, if any
 		for player in Experiments.AssignedGroupIdByPlayer do
 			setAssignedPlayerGroupId(player, nil)
 		end
 
-	elseif response.playerIdsByGroupId then
-		for groupIdString: string, groupPlayerIds in response.playerIdsByGroupId do
+	elseif (assignmentResponse.targetType == "player") and assignmentResponse.playerIdsByGroupId then
+		for groupIdString, groupPlayerIds in assignmentResponse.playerIdsByGroupId do
 			local groupId = tonumber(groupIdString) :: number
-			for _, playerId in groupPlayerIds do
-				local player = Players:GetPlayerByUserId(playerId)
+			for _, playerIdString in groupPlayerIds do
+				local playerId = tonumber(playerIdString)
+				local player = playerId and Players:GetPlayerByUserId(playerId)
 				if player then
 					setAssignedPlayerGroupId(player, groupId)
 				end

--- a/src/Infra/Server/Modules/Experiments.luau
+++ b/src/Infra/Server/Modules/Experiments.luau
@@ -8,6 +8,8 @@ local Players = game:GetService("Players")
 local GBRequests = shared.GBMod("GBRequests")
 local Signal = shared.GBMod("Signal")
 local Utilities = shared.GBMod("Utilities")
+local SignalConnection = shared.GBMod("SignalConnection") ---@module SignalConnection
+local Cleaner = shared.GBMod("Cleaner") ---@module Cleaner
 
 -- Types
 type ConfigSnapshot = {
@@ -46,7 +48,7 @@ type PlayerAssignmentResponse = BaseAssignmentResponse & {
 }
 type EmptyAssignmentResponse = nil
 type AssignmentResponse =
-	| GameserverAssignmentResponse
+	GameserverAssignmentResponse
 	| PlayerAssignmentResponse
 	| EmptyAssignmentResponse
 
@@ -113,6 +115,8 @@ Experiments.OnAssignedServerConfigChanged = Signal.new()
 Experiments.OnAssignedPlayerConfigChanged = Signal.new()
 
 Experiments.CanonicalServerConfig = nil :: ConfigSnapshot?
+
+Experiments.OnAssignmentDisabling = Signal.new()
 
 --[[
 	Updates whether assignments are being requested or not, based on the given
@@ -252,6 +256,66 @@ function Experiments:ProcessExperimentReassignmentRequest(request: ExperimentRea
 end
 
 --[[
+	Calls `callback` with the experiment group ID applied to a player once it's known.
+	If assignment is disabled, or the player leaves, this may be `nil`.
+
+	Returns a function to cancel listening.
+]]
+function Experiments:ListenForPlayerAssignment(player: Player, callback: (groupId: number?) -> ()): RBXScriptSignal
+	local listenerCleaner = Cleaner.new()
+	local connection = SignalConnection.new(function()
+		listenerCleaner:Destroy()
+	end)
+
+	local function resolve(groupId: number?)
+		connection:Disconnect() -- Disconnect the listener
+		task.spawn(callback, groupId)
+
+		return connection -- Return dead connection
+	end
+
+	-- If assignment is not enabled, immediately return nil
+	if not currentAssignmentState then
+		return resolve(nil)
+	end
+
+	-- If server is assigned, return the assigned group ID
+	if Experiments.AssignedServerGroupId then
+		return resolve(Experiments.AssignedServerGroupId)
+	end
+
+	-- If player is assigned, return the assigned group ID
+	if Experiments.AssignedGroupIdByPlayer[player] then
+		return resolve(Experiments.AssignedGroupIdByPlayer[player])
+	end
+
+	-- Wait for assignment to change for player or server, or for it to be disabled
+	listenerCleaner:Add(Experiments.OnPlayerGroupIdChanged:Connect(function (changedPlayer: Player, newGroupId: number?)
+		if (changedPlayer == player) and newGroupId then
+			resolve(newGroupId)
+		end
+	end))
+
+	listenerCleaner:Add(Experiments.OnServerGroupIdChanged:Connect(function (newGroupId: number?)
+		if newGroupId then
+			resolve(newGroupId)
+		end
+	end))
+
+	listenerCleaner:Add(Experiments.OnAssignmentDisabling:Connect(function ()
+		resolve(nil)
+	end))
+
+	listenerCleaner:Add(Players.PlayerRemoving:Connect(function (leavingPlayer: Player)
+		if leavingPlayer == player then
+			resolve(nil)
+		end
+	end))
+
+	return connection
+end
+
+--[[
 	Starts requesting experiment assignments for players and the server.
 
 	Called when the game receives GB configs and becomes aware of available
@@ -297,6 +361,8 @@ function disableAssignment()
 	if not currentAssignmentState then
 		return
 	end
+
+	Experiments.OnAssignmentDisabling:Fire()
 
 	-- Clear current assignments
 	setAssignedServerGroupId(nil)

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -133,7 +133,7 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 	}
 
 	-- JobId is undefined in studio so send a hard coded default for this environment
-	if isStudio == true then
+	if isStudio then
 		headers["serverid"] = "00000000-0000-0000-0000-000000000000"
 	else
 		headers["serverid"] = game.JobId

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -133,7 +133,7 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 	}
 
 	-- JobId is undefined in studio so send a hard coded default for this environment
-	if isStudio == false then
+	if isStudio == true then
 		headers["serverid"] = "00000000-0000-0000-0000-000000000000"
 	else
 		headers["serverid"] = game.JobId

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -130,6 +130,8 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 		["isstudio"] = tostring(isStudio),
 		["sdkversion"] = MetaData.version,
 		["universeid"] = tostring(game.GameId),
+		["placeid"] = tostring(game.PlaceId),
+		["placeversion"] = tostring(game.PlaceVersion)
 	}
 
 	-- JobId is undefined in studio so send a hard coded default for this environment

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -124,15 +124,16 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 	local authKey = YeildForKey()
 
 	-- Define relevant headers. Backend enforces header presence unless specified.
+	local isStudio = RunService:IsStudio()
 	local headers = {
 		["authorization"] = authKey,
-		["isstudio"] = tostring(RunService:IsStudio()),
+		["isstudio"] = tostring(isStudio),
 		["sdkversion"] = MetaData.version,
 		["universeid"] = tostring(game.GameId),
 	}
 
 	-- JobId is undefined in studio so send a hard coded default for this environment
-	if headers["isstudio"] then
+	if isStudio == false then
 		headers["serverid"] = "00000000-0000-0000-0000-000000000000"
 	else
 		headers["serverid"] = game.JobId

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -130,8 +130,6 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 		["isstudio"] = tostring(isStudio),
 		["sdkversion"] = MetaData.version,
 		["universeid"] = tostring(game.GameId),
-		["placeid"] = tostring(game.PlaceId),
-		["placeversion"] = tostring(game.PlaceVersion)
 	}
 
 	-- JobId is undefined in studio so send a hard coded default for this environment

--- a/src/Infra/Server/Modules/RequestFunctionHandler/RequestFunctions.luau
+++ b/src/Infra/Server/Modules/RequestFunctionHandler/RequestFunctions.luau
@@ -25,8 +25,7 @@ local requestFunctions = {}
 requestFunctions.funcs = {
 	-- host_only: true
 	-- async: true
-	["Ban"] = function(request)
-		local args = request.args
+	["Ban"] = function(args)
 		local userIdentifier = args.user_identifier
 		local success
 		
@@ -39,7 +38,7 @@ requestFunctions.funcs = {
 			
 			-- If the service failed, we can't proceed
 			if not success then
-				shared.GBMod("GBRequests"):SendFailure(request)
+				error("Failed to resolve userId")
 				return
 			end
 		else
@@ -62,8 +61,7 @@ requestFunctions.funcs = {
 	
 	-- host_only: true
 	-- async: true
-	["Unban"] = function(request)
-		local args = request.args
+	["Unban"] = function(args)
 		local userIdentifier = args.user_identifier
 		local success
 
@@ -76,7 +74,7 @@ requestFunctions.funcs = {
 
 			-- If the service failed, we can't proceed
 			if not success then
-				shared.GBMod("GBRequests"):SendFailure(request)
+				error("Failed to resolve userId")
 				return
 			end
 		else
@@ -96,8 +94,7 @@ requestFunctions.funcs = {
 	
 	-- host_only: false
 	-- async: true
-	["Kick"] = function(request)
-		local args = request.args
+	["Kick"] = function(args)
 		local userIdentifier = args.user_identifier
 		-- We support UserIds + usernames from the dashboard
 		if tonumber(userIdentifier) then
@@ -126,38 +123,24 @@ requestFunctions.funcs = {
 	
 	-- host_only: false
 	-- async: false
-	["UpdateConfigs"] = function(request)
-		Utilities.GBLog("Received config update request", request)
-		Updater:UpdateConfigs(request.args)
+	["UpdateConfigs"] = function(args)
+		Utilities.GBLog("Received config update request")
+		Updater:UpdateConfigs(args)
 	end;
 
 	-- host_only: false
 	-- async: false
-	["PropagateAvailableExperiments"] = function (request)
-		Utilities.GBLog("Received experiment update request", request)
-		Experiments:UpdateStateFromAvailableExperiments(request.args)
+	["PropagateAvailableExperiments"] = function (args)
+		Utilities.GBLog("Received experiment update request")
+		Experiments:UpdateStateFromAvailableExperiments(args)
 	end,
 
 	-- host_only: false
 	-- async: false
-	["PropagateExperimentReassignment"] = function (request)
-		Utilities.GBLog("Received experiment reassignment request", request)
-		Experiments:ProcessExperimentReassignmentRequest(request.args)
-	end,
-
-	
-	-- Not yet implemented
-	--["CustomJob"] = function(request)
-	--	local res, success = utilities.promiseReturn(0, function()
-	--		shared.GBMod("CustomJobs").executeCustomJob(request.args)
-	--	end)
-		
-	--	if success then
-	--		shared.GBMod("GBRequests"):SendFailure(request)
-	--	else
-	--		shared.GBMod("GBRequests"):SendSuccess(request, {res})
-	--	end
-	--end;
+	["PropagateExperimentReassignment"] = function (args)
+		Utilities.GBLog("Received experiment reassignment request")
+		Experiments:ProcessExperimentReassignmentRequest(args)
+	end
 }
 
 return requestFunctions

--- a/src/Infra/Server/Modules/RequestFunctionHandler/init.lua
+++ b/src/Infra/Server/Modules/RequestFunctionHandler/init.lua
@@ -175,7 +175,7 @@ function RequestFunctionHandler:ExecuteRequests(requests : {})
                             return
                         end
 
-                        local success, data = pcall(requestFunc, request)
+                        local success, data = pcall(requestFunc, request.args)
 
                         if not success then
                             AddResult(false, request.requestId, {details=data})
@@ -204,7 +204,7 @@ function RequestFunctionHandler:ExecuteRequests(requests : {})
                     end
 
                     -- Either run relevant function in its own thread or (potentially) yield and run sequentially as determined by request details
-                    if request.details.async then
+                    if request.details.async or request.details.custom then
                         task.spawn(performRequest)
                     else
                         performRequest()

--- a/src/Infra/Server/Modules/ServerClientInfoHandler.lua
+++ b/src/Infra/Server/Modules/ServerClientInfoHandler.lua
@@ -61,21 +61,19 @@ function ServerClientInfoHandler:GetClientInfo(player : Player | number, key : s
     return ClientInfoCache[player][key]
 end
 
-function ServerClientInfoHandler:OnClientInfoResolved(player : Player, timeoutSeconds : number, callback : (timedout : boolean, info : { [string] : any }) -> nil)
+function ServerClientInfoHandler:GetDefaultInfo()
+    return table.clone(DEFAULT_INFO)
+end
+
+function ServerClientInfoHandler:OnClientInfoResolved(player : Player, callback : (info : { [string] : any }) -> nil)
     if ClientInfoCache[player] then
-        callback(false, table.clone(ClientInfoCache[player]))
+        callback(table.clone(ClientInfoCache[player]))
         return
     end
 
-    local timeout = SignalTimeout.new(timeoutSeconds, ClientInfoResolvedSignal, function(resolvedPlayer : Player)
-        return resolvedPlayer == player
-    end)
-
-    return timeout:Once(function(timedout : boolean, _, info : { [string] : any }?)
-        if timedout or not info then
-            callback(true, table.clone(DEFAULT_INFO))
-        elseif info then
-            callback(false, table.clone(info))
+    return ClientInfoResolvedSignal:Connect(function(resolvedPlayer : Player, clientInfo : { [string] : any })
+        if resolvedPlayer == player then
+            callback(table.clone(clientInfo))
         end
     end)
 end

--- a/src/Infra/Server/Modules/ServerClientInfoHandler.lua
+++ b/src/Infra/Server/Modules/ServerClientInfoHandler.lua
@@ -35,7 +35,9 @@ local ClientInfoChangedSignal = Signal.new()
 --= Constants =--
 
 local DEFAULT_INFO = {
-    device = "unknown",
+    inputType = "unknown" :: "keyboard" | "gamepad" | "touch" | "unknown",
+    device = "unknown" :: "pc" | "mobile" | "console" | "vr" | "unknown",
+    deviceSubType = "unknown" :: "tablet" | "phone" | "xbox" | "playstation" | "unknown",
     friendsOnline = 0,
 }
 
@@ -123,23 +125,27 @@ function ServerClientInfoHandler:Init()
         ClientInfoCache[player] = nil
     end)
 
-    ClientInfoRemote.OnServerEvent:Connect(function(player : Player, updatedKey : string, updatedValue : any)
-        if not updatedKey or not updatedValue then
-            return
-        end
-
-        if DEFAULT_INFO[updatedKey] == nil then
-            return
-        end
-
+    ClientInfoRemote.OnServerEvent:Connect(function(player : Player, updatedInfo : { [string] : any })
+       
         local isNew = false
         if not ClientInfoCache[player] then
             ClientInfoCache[player] = table.clone(DEFAULT_INFO)
             isNew = true
         end
 
-        ClientInfoCache[player][updatedKey] = updatedValue
-        ClientInfoChangedSignal:Fire(player, updatedKey, updatedValue)
+        for updatedKey, updatedValue in pairs(updatedInfo) do
+            if DEFAULT_INFO[updatedKey] == nil then
+                return
+            end
+
+            local currentValue = ClientInfoCache[player][updatedKey]
+            if currentValue == updatedValue then
+                continue
+            end
+
+            ClientInfoCache[player][updatedKey] = updatedValue
+            ClientInfoChangedSignal:Fire(player, updatedKey, updatedValue)
+        end
 
         if isNew then
             ClientInfoResolvedSignal:Fire(player, ClientInfoCache[player])

--- a/src/Infra/Server/Modules/ServerStateReporter.luau
+++ b/src/Infra/Server/Modules/ServerStateReporter.luau
@@ -66,11 +66,11 @@ local function AggregateMetric(metricHistory: {number})
         max = max,
         sum = sum,
         average = sum / #metricHistory,
-        median = metricHistory[math.floor(#metricHistory / 2)],
-        p25 = metricHistory[math.floor(#metricHistory * 0.25)],
-        p75 = metricHistory[math.floor(#metricHistory * 0.75)],
-        p90 = metricHistory[math.floor(#metricHistory * 0.90)],
-        p99 = metricHistory[math.floor(#metricHistory * 0.99)]
+        median = metricHistory[math.max(math.floor(#metricHistory / 2), 1)],
+        p25 = metricHistory[math.max(math.floor(#metricHistory * 0.25), 1)],
+        p75 = metricHistory[math.max(math.floor(#metricHistory * 0.75), 1)],
+        p90 = metricHistory[math.max(math.floor(#metricHistory * 0.90), 1)],
+        p99 = metricHistory[math.max(math.floor(#metricHistory * 0.99), 1)]
     }
 end
 

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -215,14 +215,6 @@ function Updater:Init()
 		end
 	end
 
-	-- Update marker properties when experiments are running
-	Experiments.OnServerGroupIdChanged:Connect(function (groupId)
-		EngagementMarkers:SetServerExperimentGroupId(groupId)
-	end)
-	Experiments.OnPlayerGroupIdChanged:Connect(function (player, groupId)
-		EngagementMarkers:SetPlayerExperimentGroupId(player, groupId)
-	end)
-
 	-- Update configs for server with initialization flag
 	self:UpdateConfigs(newConfigs, true)
 

--- a/src/Infra/Shared/Modules/Cleaner.lua
+++ b/src/Infra/Shared/Modules/Cleaner.lua
@@ -48,7 +48,6 @@ function Cleaner:Add(object : Instance | RBXScriptConnection | {Destroy : () -> 
     table.insert(self._toClean, object)
 end
 
-Cleaner.Clean = Cleaner.Destroy
 function Cleaner:Destroy()
     for _, object in ipairs(self._toClean) do
         if typeof(object) == "RBXScriptConnection" then
@@ -58,5 +57,7 @@ function Cleaner:Destroy()
         end
     end
 end
+
+Cleaner.Clean = Cleaner.Destroy
 
 return Cleaner

--- a/src/Infra/Shared/Modules/Timer.lua
+++ b/src/Infra/Shared/Modules/Timer.lua
@@ -1,0 +1,70 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+
+    Timer.lua
+    
+    Description:
+        Simple timer that fires a signal when the time is up.
+    
+--]]
+
+--= Root =--
+
+local Timer = {}
+Timer.__index = Timer
+
+--= Roblox Services =--
+
+local RunService = game:GetService("RunService")
+
+--= Dependencies =--
+
+local Signal = shared.GBMod("Signal") ---@module Signal
+local Cleaner = shared.GBMod("Cleaner") ---@module Cleaner
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+--= Variables =--
+
+--= Internal Functions =--
+
+--= Constructor =--
+
+function Timer.new(timeSeconds : number)
+    local self = setmetatable({}, Timer)
+
+    self._cleaner = Cleaner.new()
+    self._startTick = tick()
+    self._timedOutSignal = Signal.new()
+
+    self._cleaner:Add(self._timedOutSignal)
+    self._cleaner:Add(RunService.Heartbeat:Connect(function()
+        if tick() - self._startTick >= timeSeconds then
+            self._timedOutSignal:Fire(true)
+            self:Destroy()
+        end
+    end))
+
+    return self
+end
+
+--= Methods =--
+
+function Timer:OnEnd(callback : (...any) -> ())
+    return self._timedOutSignal:Once(function(timedOut, ...)
+        if timedOut then
+            callback(...)
+        end
+    end)
+end
+
+function Timer:Destroy()
+    self._cleaner:Destroy()
+end
+
+return Timer


### PR DESCRIPTION
Features:

- "deviceSubType" & "inputType" properties on markers
- "placeVersion" & "placeId" properties on markers
- Experiments
- Custom jobs

Fixes:

- "ServerId" Is now sent correctly
-  Configs set to false on the client won't return nil
-  Server heartbeat values are now clamped to a minimum of 1 for `median`, `p99`, `p90`, `p75`, & `p25`