### PR TITLE
feat: sessionId preservation through teleports

### DIFF
--- a/src/Infra/Client/Modules/ClientConfigs.lua
+++ b/src/Infra/Client/Modules/ClientConfigs.lua
@@ -5,7 +5,7 @@
     ClientConfigs.lua
     
     Description:
-        No description provided.
+        Internal module for managing client-side configuration data.
     
 --]]
 

--- a/src/Infra/Client/Modules/ClientFriendHandler.lua
+++ b/src/Infra/Client/Modules/ClientFriendHandler.lua
@@ -1,0 +1,100 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+    
+    ClientFriendHandler.lua
+    
+    Description:
+        No description provided.
+    
+--]]
+
+
+--= Root =--
+local ClientFriendHandler = { }
+
+--= Roblox Services =--
+
+local Players = game:GetService("Players")
+
+--= Dependencies =--
+
+local ClientInfoHandler = shared.GBMod("ClientInfoHandler") ---@module ClientInfoHandler
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+--= Variables =--
+
+local FriendCache = {} :: {[number] : boolean}
+local FriendsOnline = 0
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+local function UpdateFriendCache()
+    local foundFriendsOnline = 0
+    local success, errorMessage = pcall(function() -- Minimizes internal HTTP requests
+        local friendsList = Players:GetFriendsAsync(Players.LocalPlayer.UserId)
+        
+        repeat
+            local list = friendsList:GetCurrentPage()
+            for _, friend in ipairs(list) do
+                if Players:GetPlayerByUserId(friend.Id) then
+                    foundFriendsOnline += 1
+                end
+                FriendCache[friend.Id] = true
+            end
+
+            if not friendsList.IsFinished then
+                friendsList:AdvanceToNextPageAsync()
+            end
+        until friendsList.IsFinished
+    end)
+
+    -- client only sends initial total time and friends online count
+
+    local hasFriendsOnline = ClientInfoHandler:GetClientInfo("hasFriendsOnline") or false
+
+    if hasFriendsOnline == true and foundFriendsOnline <= 0 then
+        ClientInfoHandler:UpdateClientInfo("totalFriendPlaytime", (ClientInfoHandler:GetClientInfo("totalFriendPlaytime") or 0) + os.clock() - (ClientInfoHandler:GetClientInfo("friendClockStart")))
+    elseif foundFriendsOnline > 0 and hasFriendsOnline == false then
+        ClientInfoHandler:UpdateClientInfo("friendClockStart", os.clock())
+    end
+
+    FriendsOnline = foundFriendsOnline
+    ClientInfoHandler:UpdateClientInfo("hasFriendsOnline", FriendsOnline > 0)
+
+    return success, errorMessage
+end
+
+--= API Functions =--
+
+--= Initializers =--
+function ClientFriendHandler:Init()
+    task.spawn(function()
+        Players.PlayerAdded:Connect(function(player : Player)
+            if FriendCache[player.UserId] then
+                FriendsOnline += 1
+            end
+        end)
+
+        Players.PlayerRemoving:Connect(function(player : Player)
+            if FriendCache[player.UserId] then
+                FriendsOnline -= 1
+            end
+        end)
+
+        UpdateFriendCache()
+        while task.wait(60 * 10) do
+            UpdateFriendCache()
+        end
+    end)
+end
+
+--= Return Module =--
+return ClientFriendHandler

--- a/src/Infra/Client/Modules/ClientFriendHandler.lua
+++ b/src/Infra/Client/Modules/ClientFriendHandler.lua
@@ -41,7 +41,7 @@ local function UpdateFriendCache()
     local success, errorMessage = pcall(function() -- Minimizes internal HTTP requests
         local friendsList = Players:GetFriendsAsync(Players.LocalPlayer.UserId)
         
-        repeat
+        while true do
             local list = friendsList:GetCurrentPage()
             for _, friend in ipairs(list) do
                 if Players:GetPlayerByUserId(friend.Id) then
@@ -50,10 +50,12 @@ local function UpdateFriendCache()
                 FriendCache[friend.Id] = true
             end
 
-            if not friendsList.IsFinished then
+            if friendsList.IsFinished then
+                break
+            else
                 friendsList:AdvanceToNextPageAsync()
             end
-        until friendsList.IsFinished
+        end
     end)
 
     -- client only sends initial total time and friends online count

--- a/src/Infra/Client/Modules/ClientInfoHandler.lua
+++ b/src/Infra/Client/Modules/ClientInfoHandler.lua
@@ -5,7 +5,7 @@
     ClientInfoHandler.lua
     
     Description:
-        No description provided.
+        Module for managing reported client information and product pricing.
     
 --]]
 

--- a/src/Infra/Client/Modules/ClientInfoHandler.lua
+++ b/src/Infra/Client/Modules/ClientInfoHandler.lua
@@ -30,7 +30,7 @@ local GetRemote = shared.GBMod("GetRemote")
 
 local ClientInfoRemote = GetRemote("Event", "ClientInfoChanged")
 local ClientProductPriceRemote = GetRemote("Function", "GetProductPrice")
-local SessionIdResovedRemote = GetRemote("Event", "SessionIdResolved")
+local SessionPreservationRemote = GetRemote("Event", "SessionPreservation")
 
 --= Constants =--
 
@@ -95,7 +95,7 @@ end
 --= Initializers =--
 function ClientInfoHandler:Init()
     UpdateClientInfo("device", self:GetDeviceType(), true)
-    UpdateClientInfo("preservedSessionId", TeleportService:GetTeleportSetting("GAMEBEAST_SID") or "")
+    UpdateClientInfo("preservedSessionData", TeleportService:GetTeleportSetting("GAMEBEAST_SESSION") or "")
 
     -- Friends online
     task.spawn(function()
@@ -138,10 +138,8 @@ function ClientInfoHandler:Init()
     end
 
     -- Session ID resolution
-    SessionIdResovedRemote.OnClientEvent:Connect(function(sessionId : string)
-        if sessionId and sessionId ~= "" then
-            TeleportService:SetTeleportSetting("GAMEBEAST_SID", sessionId)
-        end
+    SessionPreservationRemote.OnClientEvent:Connect(function(sessionInfo : {[string] : any})
+        TeleportService:SetTeleportSetting("GAMEBEAST_SESSION", sessionInfo)
     end)
 end
 

--- a/src/Infra/Client/Modules/ClientInfoHandler.lua
+++ b/src/Infra/Client/Modules/ClientInfoHandler.lua
@@ -15,14 +15,11 @@ local ClientInfoHandler = { }
 --= Roblox Services =--
 
 local MarketplaceService = game:GetService("MarketplaceService")
-local Players = game:GetService("Players")
-local TeleportService = game:GetService("TeleportService")
-local UserInputService = game:GetService("UserInputService")
-local VRService = game:GetService("VRService")
 
 --= Dependencies =--
 
 local GetRemote = shared.GBMod("GetRemote")
+local ClientSessionPreservation = shared.GBMod("ClientSessionPreservation") ---@module ClientSessionPreservation
 
 --= Types =--
 
@@ -30,26 +27,37 @@ local GetRemote = shared.GBMod("GetRemote")
 
 local ClientInfoRemote = GetRemote("Event", "ClientInfoChanged")
 local ClientProductPriceRemote = GetRemote("Function", "GetProductPrice")
-local SessionPreservationRemote = GetRemote("Event", "SessionPreservation")
 
 --= Constants =--
+
+local REQUIRED_KEYS = {
+    device = true,
+    deviceSubType = true,
+    inputType = true,
+}
 
 --= Variables =--
 
 local ProductInfoCache = {} :: {[number] : {PriceInRobux : number}}
 local CurrentClientInfoCache = {} :: {[string] : any}
-local FriendCache = {} :: {[number] : boolean}
-local FriendsOnline = 0
 local PendingUpdate = false
-local CurrentInputType = nil
 
 --= Public Variables =--
 
 --= Internal Functions =--
 
-local function UpdateClientInfo(key : string, value : any, force : boolean?)
-    if CurrentClientInfoCache[key] ~= value or force then
+--= API Functions =--
+
+function ClientInfoHandler:UpdateClientInfo(key : string, value : any)
+    if CurrentClientInfoCache[key] ~= value then
         CurrentClientInfoCache[key] = value
+        ClientSessionPreservation:UpdateStoredData(key, value)
+
+        for key in REQUIRED_KEYS do
+            if not CurrentClientInfoCache[key] then
+                return -- Will not send signal that client info is ready until all required keys are set
+            end
+        end
 
         if PendingUpdate then
             return
@@ -63,150 +71,15 @@ local function UpdateClientInfo(key : string, value : any, force : boolean?)
     end
 end
 
-local function UpdateFriendCache()
-    local foundFriendsOnline = 0
-    local success, errorMessage = pcall(function() -- Minimizes internal HTTP requests
-        local friendsList = Players:GetFriendsAsync(Players.LocalPlayer.UserId)
-        
-        repeat
-            local list = friendsList:GetCurrentPage()
-            for _, friend in ipairs(list) do
-                if Players:GetPlayerByUserId(friend.Id) then
-                    foundFriendsOnline += 1
-                end
-                FriendCache[friend.Id] = true
-            end
-
-            if not friendsList.IsFinished then
-                friendsList:AdvanceToNextPageAsync()
-            end
-        until friendsList.IsFinished
-    end)
-
-    FriendsOnline = foundFriendsOnline
-    UpdateClientInfo("friendsOnline", FriendsOnline)
+function ClientInfoHandler:GetClientInfo(key : string) : any
+    return CurrentClientInfoCache[key]
 end
-
-local function DetermineInputTypeString(InputEnum) 
-    if InputEnum == Enum.UserInputType.Keyboard then
-        return "keyboard"
-    elseif InputEnum == Enum.UserInputType.Touch then
-        return "touch"
-    elseif string.match(tostring(InputEnum),"Gamepad") then
-        return "gamepad"
-    end
-end
-
---= API Functions =--
-
-function ClientInfoHandler:GetDeviceType() : (string, string)
-    -- Determine device type
-    local deviceType = "unknown"
-    if UserInputService.VREnabled or VRService.VREnabled then
-        deviceType = "vr"
-    elseif UserInputService.TouchEnabled and not UserInputService.KeyboardEnabled then
-		deviceType = "mobile"
-	elseif UserInputService.GamepadEnabled and not UserInputService.KeyboardEnabled then
-		deviceType = "console"
-	elseif UserInputService.KeyboardEnabled then
-		deviceType = "pc"
-	end
-
-    -- Determine device subtype
-    local deviceSubType = "unknown"
-    if deviceType == "mobile" then
-        local camera = workspace.CurrentCamera
-        if camera then
-            local longestSide = math.max(camera.ViewportSize.X, camera.ViewportSize.Y)
-            local shortestSide = math.min(camera.ViewportSize.X, camera.ViewportSize.Y)
-            local aspectRatio = longestSide / shortestSide
-            if aspectRatio > 1.8 then
-                deviceSubType = "phone"
-            elseif aspectRatio <= 1.7 then
-                deviceSubType = "tablet"
-            else -- Devices in this range can be either phone or tablet equally. Older devices share the 16:9 aspect ratio.
-                deviceSubType = "phone" -- We'll assume phone for now, since phone users are more common.
-            end
-        end
-    elseif deviceType == "console" then
-        local imageUrl = UserInputService:GetImageForKeyCode(Enum.KeyCode.ButtonX)
-        if string.find(imageUrl, "Xbox") then
-            deviceSubType = "xbox"
-        elseif string.find(imageUrl, "PlayStation") then
-            deviceSubType = "playstation"
-        else
-            deviceSubType = "unknown"
-        end
-    elseif deviceType == "vr" then
-        deviceSubType = "unknown" -- No reliable way to determine VR headset type in Roblox.
-    elseif deviceType == "pc" then
-        deviceSubType = "unknown" -- No reliable way to determine PC type in Roblox
-    end
-
-    return deviceType, deviceSubType
-end
-
-
 
 --= Initializers =--
-function ClientInfoHandler:Init()
-    UpdateClientInfo("preservedSessionData", TeleportService:GetTeleportSetting("GAMEBEAST_SESSION") or "")
-    local deviceType, deviceSubType = self:GetDeviceType()
-    UpdateClientInfo("deviceSubType", deviceSubType)
-    UpdateClientInfo("device", deviceType, true)
-
-    -- Input type detection
-
-    local function inputTypeChanged(inputType : string)
-        if CurrentInputType ~= inputType then
-            CurrentInputType = inputType
-            UpdateClientInfo("inputType", CurrentInputType)
-        end
+do
+    for key, value in ClientSessionPreservation:GetStoredData() do
+        ClientInfoHandler:UpdateClientInfo(key, value)
     end
-
-    if UserInputService.GamepadEnabled then
-        inputTypeChanged("gamepad")
-    elseif UserInputService.TouchEnabled then
-        inputTypeChanged("touch")
-    else
-        inputTypeChanged("keyboard")
-    end
-
-    --// Detect CurrentInputType changes from 'LastInputType'
-    UserInputService.LastInputTypeChanged:Connect(function(lastType)
-        local newType = DetermineInputTypeString(lastType)
-        if newType and newType ~= CurrentInputType then
-            inputTypeChanged(newType)
-        end
-    end)
-
-     UserInputService.InputChanged:Connect(function(InputObject)
-        if InputObject.UserInputType == Enum.UserInputType.MouseMovement then
-            inputTypeChanged("keyboard")
-        end
-    end)
-
-    -- Friends online
-    task.spawn(function()
-        Players.PlayerAdded:Connect(function(player : Player)
-            if FriendCache[player.UserId] then
-                FriendsOnline += 1
-                UpdateClientInfo("friendsOnline", FriendsOnline)
-            end
-        end)
-
-        Players.PlayerRemoving:Connect(function(player : Player)
-            if FriendCache[player.UserId] then
-                FriendsOnline -= 1
-                UpdateClientInfo("friendsOnline", FriendsOnline)
-            end
-        end)
-
-        UpdateFriendCache()
-        while task.wait(60 * 10) do
-            UpdateFriendCache()
-        end
-    end)
 
     -- Geographic pricing
     ClientProductPriceRemote.OnClientInvoke = function(productId : number, productType : Enum.InfoType) : number
@@ -226,9 +99,8 @@ function ClientInfoHandler:Init()
         end
     end
 
-    -- Session ID resolution
-    SessionPreservationRemote.OnClientEvent:Connect(function(sessionInfo : {[string] : any})
-        TeleportService:SetTeleportSetting("GAMEBEAST_SESSION", sessionInfo)
+    ClientInfoRemote.OnClientEvent:Connect(function(key : string, value : any)
+        ClientInfoHandler:UpdateClientInfo(key, value)
     end)
 end
 

--- a/src/Infra/Client/Modules/ClientInfoHandler.lua
+++ b/src/Infra/Client/Modules/ClientInfoHandler.lua
@@ -16,6 +16,7 @@ local ClientInfoHandler = { }
 
 local MarketplaceService = game:GetService("MarketplaceService")
 local Players = game:GetService("Players")
+local TeleportService = game:GetService("TeleportService")
 local UserInputService = game:GetService("UserInputService")
 local VRService = game:GetService("VRService")
 
@@ -29,6 +30,7 @@ local GetRemote = shared.GBMod("GetRemote")
 
 local ClientInfoRemote = GetRemote("Event", "ClientInfoChanged")
 local ClientProductPriceRemote = GetRemote("Function", "GetProductPrice")
+local SessionIdResovedRemote = GetRemote("Event", "SessionIdResolved")
 
 --= Constants =--
 
@@ -93,6 +95,7 @@ end
 --= Initializers =--
 function ClientInfoHandler:Init()
     UpdateClientInfo("device", self:GetDeviceType(), true)
+    UpdateClientInfo("preservedSessionId", TeleportService:GetTeleportSetting("GAMEBEAST_SID") or "")
 
     -- Friends online
     task.spawn(function()
@@ -133,6 +136,13 @@ function ClientInfoHandler:Init()
             return nil
         end
     end
+
+    -- Session ID resolution
+    SessionIdResovedRemote.OnClientEvent:Connect(function(sessionId : string)
+        if sessionId and sessionId ~= "" then
+            TeleportService:SetTeleportSetting("GAMEBEAST_SID", sessionId)
+        end
+    end)
 end
 
 --= Return Module =--

--- a/src/Infra/Client/Modules/ClientInputHandler.lua
+++ b/src/Infra/Client/Modules/ClientInputHandler.lua
@@ -1,0 +1,148 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+	All rights reserved.
+
+    ClientInputHandler.luau
+
+    Description:
+        Tracks the current input type and device type of the client.
+]]
+
+--= Root =--
+local ClientInputHandler = { }
+
+--= Roblox Services =--
+
+local UserInputService = game:GetService("UserInputService")
+local VRService = game:GetService("VRService")
+
+--= Dependencies =--
+
+local ClientInfoHandler = shared.GBMod("ClientInfoHandler") ---@module ClientInfoHandler
+local Signal = shared.GBMod("Signal") ---@module Signal
+
+--= Types =--
+
+--= Object References =--
+
+local InputTypeChangedSignal = Signal.new()
+
+--= Constants =--
+
+--= Variables =--
+
+local CurrentInputType = nil
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+local function DetermineInputTypeString(inputEnum) 
+    if inputEnum == Enum.UserInputType.Keyboard then
+        return "keyboard"
+    elseif inputEnum == Enum.UserInputType.Touch then
+        return "touch"
+    elseif string.match(tostring(inputEnum),"Gamepad") then
+        return "gamepad"
+    end
+end
+--= API Functions =--
+
+--= API Functions =--
+
+function ClientInputHandler:GetDeviceType() : (string, string)
+    -- Determine device type
+    local deviceType = "unknown"
+    if UserInputService.VREnabled or VRService.VREnabled then
+        deviceType = "vr"
+    elseif UserInputService.TouchEnabled and not UserInputService.KeyboardEnabled then
+		deviceType = "mobile"
+	elseif UserInputService.GamepadEnabled and not UserInputService.KeyboardEnabled then
+		deviceType = "console"
+	elseif UserInputService.KeyboardEnabled then
+		deviceType = "pc"
+	end
+
+    -- Determine device subtype
+    local deviceSubType = "unknown"
+    if deviceType == "mobile" then
+        local camera = workspace.CurrentCamera
+        if camera then
+            local longestSide = math.max(camera.ViewportSize.X, camera.ViewportSize.Y)
+            local shortestSide = math.min(camera.ViewportSize.X, camera.ViewportSize.Y)
+            local aspectRatio = longestSide / shortestSide
+            if aspectRatio > 1.8 then
+                deviceSubType = "phone"
+            elseif aspectRatio <= 1.7 then
+                deviceSubType = "tablet"
+            else -- Devices in this range can be either phone or tablet equally. Older devices share the 16:9 aspect ratio.
+                deviceSubType = "phone" -- We'll assume phone for now, since phone users are more common.
+            end
+        end
+    elseif deviceType == "console" then
+        local imageUrl = UserInputService:GetImageForKeyCode(Enum.KeyCode.ButtonX)
+        if string.find(imageUrl, "Xbox") then
+            deviceSubType = "xbox"
+        elseif string.find(imageUrl, "PlayStation") then
+            deviceSubType = "playstation"
+        else
+            deviceSubType = "unknown"
+        end
+    elseif deviceType == "vr" then
+        deviceSubType = "unknown" -- No reliable way to determine VR headset type in Roblox.
+    elseif deviceType == "pc" then
+        deviceSubType = "unknown" -- No reliable way to determine PC type in Roblox
+    end
+
+    return deviceType, deviceSubType
+end
+
+function ClientInputHandler:OnInputTypeChanged(callback : (string) -> ()) : RBXScriptConnection
+    return InputTypeChangedSignal:Connect(callback)
+end
+
+function ClientInputHandler:GetCurrentInputType() : string
+    if not CurrentInputType then
+        if UserInputService.GamepadEnabled then
+            CurrentInputType = "gamepad"
+        elseif UserInputService.TouchEnabled then
+            CurrentInputType = "touch"
+        else
+            CurrentInputType = "keyboard"
+        end
+    end
+    return CurrentInputType
+end
+
+--= Initializers =--
+function ClientInputHandler:Init()
+    local function inputTypeChanged(inputType : string)
+        if CurrentInputType ~= inputType then
+            CurrentInputType = inputType
+            InputTypeChangedSignal:Fire(CurrentInputType)
+            ClientInfoHandler:UpdateClientInfo("inputType", CurrentInputType)
+        end
+    end
+
+    local deviceType, deviceSubType = self:GetDeviceType()
+    ClientInfoHandler:UpdateClientInfo("inputType", ClientInputHandler:GetCurrentInputType())
+    ClientInfoHandler:UpdateClientInfo("deviceSubType", deviceSubType)
+    ClientInfoHandler:UpdateClientInfo("device", deviceType)
+
+    --// Detect CurrentInputType changes from 'LastInputType'
+    UserInputService.LastInputTypeChanged:Connect(function(lastType)
+        local newType = DetermineInputTypeString(lastType)
+        if newType and newType ~= CurrentInputType then
+            inputTypeChanged(newType)
+        end
+    end)
+
+    UserInputService.InputChanged:Connect(function(InputObject)
+        if InputObject.UserInputType == Enum.UserInputType.MouseMovement then
+            inputTypeChanged("keyboard")
+        end
+    end)
+end
+
+--= Return Module =--
+return ClientInputHandler

--- a/src/Infra/Client/Modules/ClientSessionPreservation.lua
+++ b/src/Infra/Client/Modules/ClientSessionPreservation.lua
@@ -1,0 +1,61 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+	All rights reserved.
+
+    ClientSessionPreservation.luau
+
+    Description:
+        
+]]
+
+--= Root =--
+local ClientSessionPreservation = { }
+
+--= Roblox Services =--
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TeleportService = game:GetService("TeleportService")
+
+--= Dependencies =--
+
+local Signal = shared.GBMod("Signal") ---@module Signal
+local GetRemote = shared.GBMod("GetRemote")
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+local PRESERVED_KEYS = {
+    sessionId = true,
+    joinTime = true,
+    friendClockStart = true,
+    hasFriendsOnline = true,
+    totalFriendPlaytime = true
+}
+
+--= Variables =--
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+--= API Functions =--
+
+function ClientSessionPreservation:UpdateStoredData(key : string, value : any)
+    if PRESERVED_KEYS[key] == nil then
+        return
+    end
+
+    local sessionInfo = self:GetStoredData()
+    sessionInfo[key] = value
+
+    TeleportService:SetTeleportSetting("GAMEBEAST_SESSION", sessionInfo)
+end
+
+function ClientSessionPreservation:GetStoredData() : { [string]: any }
+    return TeleportService:GetTeleportSetting("GAMEBEAST_SESSION") or {}
+end
+
+--= Return Module =--
+return ClientSessionPreservation

--- a/src/Infra/Client/Public/Configs.lua
+++ b/src/Infra/Client/Public/Configs.lua
@@ -5,7 +5,7 @@
     Configs.lua
     
     Description:
-        No description provided.
+        Public API module for accessing client-specific configuration data.
     
 --]]
 

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -35,9 +35,6 @@ local Experiments = shared.GBMod("Experiments") ---@module Experiments
 
 --= Object References =--
 
-local SessionIdResovedRemote = GetRemote("Event", "SessionIdResolved")
-local FireMarkerEvent = GetRemote("Event", "FireMarker")
-
 --= Constants =--
 
 local CLIENT_DATA_TIMEOUT = RunService:IsStudio() and 10 or 45
@@ -70,7 +67,7 @@ local ClientInfoWarned = false
 local function GetSessionIdForPlayer(player) : string?
 	if SessionIds[player] == nil and player.Parent then
 		SessionIds[player] = HttpService:GenerateGUID(false)
-		SessionIdResovedRemote:FireClient(player, SessionIds[player])
+		ServerClientInfoHandler:UpdateClientData(player, "sessionId", SessionIds[player])
 	end
 
 	return SessionIds[player]
@@ -200,11 +197,11 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 			entry.properties.inputType = ServerClientInfoHandler:GetClientInfo(player, "inputType")
 
 			-- Attempt to resolve session ID from client info so we preserve it across game sessions.
-			local preservedSessionId = ServerClientInfoHandler:GetClientInfo(player, "preservedSessionId")
-			if preservedSessionId and preservedSessionId ~= "" then
-				entry.sessionId = preservedSessionId
+			local sessionId = ServerClientInfoHandler:GetClientInfo(player, "sessionId")
+			if sessionId and sessionId ~= "" then
+				entry.sessionId = sessionId
 				if player.Parent then
-					SessionIds[player] = preservedSessionId
+					SessionIds[player] = sessionId
 				end
 			else
 				entry.sessionId = GetSessionIdForPlayer(player)

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -5,7 +5,7 @@
 	EngagementMarkers.luau
 	
 	Description:
-		No description provided.
+		Handles processing and sending engagement markers to the Gamebeast backend.
 	
 --]]
 

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -33,6 +33,7 @@ local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@modu
 
 --= Object References =--
 
+local SessionIdResovedRemote = GetRemote("Event", "SessionIdResolved")
 local FireMarkerEvent = GetRemote("Event", "FireMarker")
 
 --= Constants =--
@@ -42,7 +43,6 @@ local MAX_EVENT_QUEUE_SIZE = 1000
 local QUEUE_CHECK_TIME = 5
 local MAX_EVENT_REPORT_TIME = 10
 local SYSTEM_MARKERS = {
-	["Died"] = true,
 	["Logout"] = true,
 	["Login"] = true,
 	["Purchase"] = true,
@@ -84,6 +84,7 @@ local ExperimentGroupIdByPlayer = {} :: {[Player]: number}
 local function GetSessionIdForPlayer(player) : string?
 	if SessionIds[player] == nil and player.Parent then
 		SessionIds[player] = HttpService:GenerateGUID(false)
+		SessionIdResovedRemote:FireClient(player, SessionIds[player])
 	end
 
 	return SessionIds[player]
@@ -164,7 +165,7 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		["timestamp"] = metaData.timestampOverride or DateTime.now().UnixTimestampMillis,
 		["type"] = markerType,
 		["userId"] = player and player.UserId, 
-		["sessionId"] = player and GetSessionIdForPlayer(player),
+		["sessionId"] = nil, -- Resolved later
 		["value"] = value,
 		["properties"] = {
 			["sdkPlatform"] = "roblox",
@@ -191,6 +192,18 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 	if player then -- Ensure marker gets fired with device info on timeout or bind to close
 		local function resolved()
 			entry.properties.device = ServerClientInfoHandler:GetClientInfo(player, "device")
+
+			-- Attempt to resolve session ID from client info so we preserve it across game sessions.
+			local preservedSessionId = ServerClientInfoHandler:GetClientInfo(player, "preservedSessionId")
+			if preservedSessionId and preservedSessionId ~= "" then
+				entry.sessionId = preservedSessionId
+				if player.Parent then
+					SessionIds[player] = preservedSessionId
+				end
+			else
+				entry.sessionId = GetSessionIdForPlayer(player)
+			end
+
 			addMarker()
 		end
 		

--- a/src/Infra/Server/Modules/EventsManager.luau
+++ b/src/Infra/Server/Modules/EventsManager.luau
@@ -5,7 +5,7 @@
 	EventsManager.luau
 	
 	Description:
-		No description provided.
+		Handles the management of defined events, including starting and ending events based on time.
 	
 --]]
 

--- a/src/Infra/Server/Modules/HostServer.luau
+++ b/src/Infra/Server/Modules/HostServer.luau
@@ -5,7 +5,8 @@
 	HostServer.luau
 	
 	Description:
-		No description provided.
+		Handles the host server role in a Gamebeast server environment.
+		Ensures that only one host server exists at a time and manages cross-server communication.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalConfigs.luau
+++ b/src/Infra/Server/Modules/InternalConfigs.luau
@@ -5,7 +5,7 @@
 	InternalConfigs.luau
 	
 	Description:
-		No description provided.
+		Internal module for managing configuration data across the server and clients.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
@@ -5,7 +5,7 @@
 	PurchaseAnalytics.luau
 	
 	Description:
-		No description provided.
+		Handles tracking purchases made by players in the server.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalMarkers/SentimentCapture.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SentimentCapture.luau
@@ -5,7 +5,8 @@
 	SentimentCapture.luau
 	
 	Description:
-		No description provided.
+		Captures player chat messages and sends them as markers for sentiment analysis.
+		Messages are filtered for compliance before being sent.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -66,6 +66,10 @@ function SessionMarkers:Init()
 			}
 
 			EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil})
+
+			PlayerStats:OnDefaultStatsResolved(function()
+				ServerClientInfoHandler:UpdateClientData(player, "joinTime", PlayerStats:GetStat(player, "join_time"))
+			end)
         end
 	end)
 
@@ -75,14 +79,14 @@ function SessionMarkers:Init()
 		LastCharPositions[player] = nil
 		
 		-- Compute session length in addition to backend for reasons(?)
-		local sessionLength = Utilities.roundNum(tick() - PlayerStats:GetStat(player, "session_length"), 0.1)
+		local clientJoinTime = ServerClientInfoHandler:GetClientInfo(player, "joinTime")
+		local sessionLength = Utilities.roundNum(os.time() - (clientJoinTime or PlayerStats:GetStat(player, "join_time")), 0.1)
 		local friendPlaytimePercent = SocialHandler:GetTotalFriendPlaytime(player)
 		local args = {
 			["sessionLength"] = sessionLength,
 			["sessionLengthPercentageWithFriends"] = if friendPlaytimePercent then Utilities.roundNum(friendPlaytimePercent/sessionLength, 0.01) else nil
 		}
 
-		
 		if ServerClientInfoHandler:IsClientInfoResolved() == true and PlayerStats:GetStat(player, "teleporting") == true then
 			-- If the player was teleporting, we don't send a Logout marker
 			return

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -24,6 +24,7 @@ local Utilities = shared.GBMod("Utilities")
 local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module Markers
 local PlayerStats = shared.GBMod("PlayerStats") ---@module PlayerStats
 local SocialHandler = shared.GBMod("SocialHandler") ---@module SocialHandler
+local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
 
 --= Types =--
 
@@ -68,7 +69,7 @@ function SessionMarkers:Init()
         end
 	end)
 
-	Players.PlayerRemoving:Connect(function(player)		
+	Players.PlayerRemoving:Connect(function(player)
 		-- Collect last position for Logout marker
 		local position = LastCharPositions[player]
 		LastCharPositions[player] = nil
@@ -82,7 +83,7 @@ function SessionMarkers:Init()
 		}
 
 		
-		if PlayerStats:GetStat(player, "teleporting") == true then
+		if ServerClientInfoHandler:IsClientInfoResolved() == true and PlayerStats:GetStat(player, "teleporting") == true then
 			-- If the player was teleporting, we don't send a Logout marker
 			return
 		end

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -18,6 +18,7 @@ local SessionMarkers = { }
 
 local Players = game:GetService("Players")
 local PolicyService = game:GetService("PolicyService")
+local AssetService = game:GetService("AssetService")
 
 --= Dependencies =--
 
@@ -36,7 +37,7 @@ local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@modu
 --= Variables =--
 
 local LastCharPositions = {}
-
+local PlacesInUniverse = {}
 
 --= Public Variables =--
 
@@ -88,7 +89,8 @@ function SessionMarkers:Init()
 			["sessionLengthPercentageWithFriends"] = if friendPlaytimePercent then Utilities.roundNum(friendPlaytimePercent/sessionLength, 0.01) else nil
 		}
 
-		if ServerClientInfoHandler:IsClientInfoResolved(player) == true and PlayerStats:GetStat(player, "teleporting") == true then
+		local teleportingToPlace = PlayerStats:GetStat(player, "teleporting_to")
+		if ServerClientInfoHandler:IsClientInfoResolved(player) == true and teleportingToPlace and PlacesInUniverse[teleportingToPlace] then
 			-- If the player was teleporting, we don't send a Logout marker
 			return
 		end
@@ -96,6 +98,32 @@ function SessionMarkers:Init()
 		-- Send Logout marker with relevant info
 		EngagementMarkers:SDKMarker("Logout", args, {player = player, position = position})
 	end)
+
+	task.spawn(function()
+		-- Collect all places in the universe for sessionId preservation
+		local success, err = pcall(function()
+			local placesPages = AssetService:GetGamePlacesAsync()
+			while true do
+				-- Wait for the places to be loaded
+				for _, place in pairs(placesPages:GetCurrentPage()) do
+					if not PlacesInUniverse[place.PlaceId] then
+						PlacesInUniverse[place.PlaceId] = place
+					end
+				end
+
+				if placesPages.IsFinished then
+					break
+				else
+					placesPages:AdvanceToNextPageAsync()
+				end
+			end
+		end)
+
+		if not success then
+			Utilities.GBWarn("Failed to get places in universe:", err)
+		end
+	end)
+	
 end
 
 --= Return Module =--

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -87,7 +87,7 @@ function SessionMarkers:Init()
 			["sessionLengthPercentageWithFriends"] = if friendPlaytimePercent then Utilities.roundNum(friendPlaytimePercent/sessionLength, 0.01) else nil
 		}
 
-		if ServerClientInfoHandler:IsClientInfoResolved() == true and PlayerStats:GetStat(player, "teleporting") == true then
+		if ServerClientInfoHandler:IsClientInfoResolved(player) == true and PlayerStats:GetStat(player, "teleporting") == true then
 			-- If the player was teleporting, we don't send a Logout marker
 			return
 		end

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -51,16 +51,21 @@ function SessionMarkers:Init()
 			LastCharPositions[player] = position
 		end)
 		
-		-- Send Login marker with relevant session information
-		local policyInfo = Utilities.promiseReturn(1, function()
-			return PolicyService:GetPolicyInfoForPlayerAsync(player)
-		end)
+		local joinData = player:GetJoinData()
+		-- Check if the player teleported into the game. Only send login marker if they did not teleport in.
+        if joinData.SourceGameId ~= game.GameId then
+            
+            -- Send Login marker with relevant session information
+			local policyInfo = Utilities.promiseReturn(1, function()
+				return PolicyService:GetPolicyInfoForPlayerAsync(player)
+			end)
 
-		local loginArgs = {
-			policyInfo = policyInfo
-		}
+			local loginArgs = {
+				policyInfo = policyInfo
+			}
 
-		EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil})
+			EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil})
+        end
 	end)
 
 	Players.PlayerRemoving:Connect(function(player)		
@@ -75,6 +80,12 @@ function SessionMarkers:Init()
 			["sessionLength"] = sessionLength,
 			["sessionLengthPercentageWithFriends"] = if friendPlaytimePercent then Utilities.roundNum(friendPlaytimePercent/sessionLength, 0.01) else nil
 		}
+
+		
+		if PlayerStats:GetStat(player, "teleporting") == true then
+			-- If the player was teleporting, we don't send a Logout marker
+			return
+		end
 
 		-- Send Logout marker with relevant info
 		EngagementMarkers:SDKMarker("Logout", args, {player = player, position = position})

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -5,7 +5,8 @@
 	SessionMarkers.luau
 	
 	Description:
-		No description provided.
+		Handles session markers for player login and logout events.
+		Tracks player session length and friend playtime percentage.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -102,6 +102,14 @@ function SocialHandler:Init()
             end
         end)
 
+        player.OnTeleport:Connect(function(teleportState)
+            if teleportState == Enum.TeleportState.Started then
+                PlayerStats:SetStat(player, "teleporting", true)
+            elseif teleportState == Enum.TeleportState.Failed then
+                PlayerStats:SetStat(player, "teleporting", false)
+            end
+        end)
+
         --NOTE: Disabled since large servers with lots of players joining will result in too many HTTP requests.
         --[[ Look for friends
         for _, potentialFriend in ipairs(Players:GetPlayers()) do
@@ -137,6 +145,7 @@ function SocialHandler:Init()
         end
     end)
 
+    
 end
 
 --= Return Module =--

--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -82,17 +82,22 @@ function SocialHandler:Init()
             }, { player = player })
         end
 
-        cacheEntry.Cleaner:GiveTask(ServerClientInfoHandler:OnClientInfoChanged(player, function(key, _)
+        cacheEntry.Cleaner:Add(ServerClientInfoHandler:OnClientInfoChanged(player, function(key, _)
             if key == "friendClockStart" then
                 cacheEntry.LastClientUpdate = os.clock()
             end
         end))
 
+        local activeTeleportCount = 0
         player.OnTeleport:Connect(function(teleportState)
-            if teleportState == Enum.TeleportState.Started then
+            if teleportState == Enum.TeleportState.RequestedFromServer then
                 PlayerStats:SetStat(player, "teleporting", true)
+                activeTeleportCount += 1
             elseif teleportState == Enum.TeleportState.Failed then
-                PlayerStats:SetStat(player, "teleporting", false)
+                activeTeleportCount -= 1
+                if activeTeleportCount <= 0 then
+                    PlayerStats:SetStat(player, "teleporting", false)
+                end
             end
         end)
     end

--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -89,14 +89,14 @@ function SocialHandler:Init()
         end))
 
         local activeTeleportCount = 0
-        player.OnTeleport:Connect(function(teleportState)
+        player.OnTeleport:Connect(function(teleportState, placeId)
             if teleportState == Enum.TeleportState.RequestedFromServer then
-                PlayerStats:SetStat(player, "teleporting", true)
+                PlayerStats:SetStat(player, "teleporting_to", placeId)
                 activeTeleportCount += 1
             elseif teleportState == Enum.TeleportState.Failed then
                 activeTeleportCount -= 1
                 if activeTeleportCount <= 0 then
-                    PlayerStats:SetStat(player, "teleporting", false)
+                    PlayerStats:SetStat(player, "teleporting_to", nil)
                 end
             end
         end)

--- a/src/Infra/Server/Modules/LocalizationCache.lua
+++ b/src/Infra/Server/Modules/LocalizationCache.lua
@@ -5,7 +5,7 @@
     LocalizationCache.lua
     
     Description:
-        No description provided.
+        Caches localization data for players, such as region and locale IDs.
     
 --]]
 

--- a/src/Infra/Server/Modules/PlayerStats.luau
+++ b/src/Infra/Server/Modules/PlayerStats.luau
@@ -27,7 +27,10 @@ local Players = game:GetService("Players")
 local DEFAULT_SCHEMA = {
     session_length = function()
 		return tick()
-	end
+	end,
+    teleporting = function()
+        return false
+    end
 }
 
 --= Variables =--

--- a/src/Infra/Server/Modules/PlayerStats.luau
+++ b/src/Infra/Server/Modules/PlayerStats.luau
@@ -5,7 +5,7 @@
     PlayerStats.luau
     
     Description:
-        No description provided.
+        Holds general player state data.
     
 --]]
 

--- a/src/Infra/Server/Modules/PlayerStats.luau
+++ b/src/Infra/Server/Modules/PlayerStats.luau
@@ -19,6 +19,7 @@ local Players = game:GetService("Players")
 --= Dependencies =--
 
 local Signal = shared.GBMod("Signal") ---@module Signal
+local Schema = shared.GBMod("Schema") ---@module Schema
 
 --= Types =--
 
@@ -28,14 +29,14 @@ local DefaultStatsResolved = Signal.new()
 
 --= Constants =--
 
-local DEFAULT_SCHEMA = {
-    join_time = function()
-		return os.time()
-	end,
-    teleporting = function()
-        return false
-    end
-}
+local DEFAULT_SCHEMA = Schema.new({
+    join_time = { default = function()
+        return os.time()
+    end, type = "number" },
+    teleporting_to = { default = function()
+        return nil 
+    end, type = {"number", "nil"} }
+})
 
 --= Variables =--
 
@@ -52,7 +53,7 @@ function PlayerStats:SetStat(player : Player, stat : string, value : any)
         self:Reset(player)
     end
 
-    if DEFAULT_SCHEMA[stat] == nil then
+    if not DEFAULT_SCHEMA:HasKey(stat) then
         error("Cannot set stat: " .. stat)
     end
 
@@ -75,10 +76,7 @@ function PlayerStats:Clear(player : Player)
 end
 
 function PlayerStats:Reset(player : Player)
-    SessionData[player] = {}
-    for statName, initializer in DEFAULT_SCHEMA do
-        SessionData[player][statName] = initializer()
-    end
+    SessionData[player] = DEFAULT_SCHEMA:GetDefault()
 
     DefaultStatsResolved:Fire(player, SessionData[player])
 end
@@ -116,8 +114,9 @@ function PlayerStats:Init()
     -- Because various modules might rely on this state, it's not safe for them to call clearPlayerSessionData themselves.
     -- Run with delay to allow time to process and then clear to avoid memory leaks. Not likely worth doing some fancy dependency/roll call system.
     Players.PlayerRemoving:Connect(function(player)
-        task.wait(3)
-        self:Clear(player)
+        task.defer(function()
+            self:Clear(player)
+        end)
     end)
 end
 

--- a/src/Infra/Server/Modules/PlayerStats.luau
+++ b/src/Infra/Server/Modules/PlayerStats.luau
@@ -18,15 +18,19 @@ local Players = game:GetService("Players")
 
 --= Dependencies =--
 
+local Signal = shared.GBMod("Signal") ---@module Signal
+
 --= Types =--
 
 --= Object References =--
 
+local DefaultStatsResolved = Signal.new()
+
 --= Constants =--
 
 local DEFAULT_SCHEMA = {
-    session_length = function()
-		return tick()
+    join_time = function()
+		return os.time()
 	end,
     teleporting = function()
         return false
@@ -63,6 +67,12 @@ function PlayerStats:Reset(player : Player)
     for statName, initializer in DEFAULT_SCHEMA do
         SessionData[player][statName] = initializer()
     end
+
+    DefaultStatsResolved:Fire(player, SessionData[player])
+end
+
+function PlayerStats:OnDefaultStatsResolved(callback : (player : Player, stats : { [string] : any }) -> nil) : RBXScriptSignal
+    return DefaultStatsResolved:Connect(callback)
 end
 
 --= Initializers =--

--- a/src/Infra/Server/Modules/PlayerStats.luau
+++ b/src/Infra/Server/Modules/PlayerStats.luau
@@ -47,6 +47,18 @@ local SessionData = {}
 
 --= API Functions =--
 
+function PlayerStats:SetStat(player : Player, stat : string, value : any)
+    if not SessionData[player] and player.Parent then
+        self:Reset(player)
+    end
+
+    if DEFAULT_SCHEMA[stat] == nil then
+        error("Cannot set stat: " .. stat)
+    end
+
+    SessionData[player][stat] = value
+end
+
 function PlayerStats:GetStats(player : Player)
     return SessionData[player]
 end
@@ -71,8 +83,21 @@ function PlayerStats:Reset(player : Player)
     DefaultStatsResolved:Fire(player, SessionData[player])
 end
 
-function PlayerStats:OnDefaultStatsResolved(callback : (player : Player, stats : { [string] : any }) -> nil) : RBXScriptSignal
-    return DefaultStatsResolved:Connect(callback)
+function PlayerStats:OnDefaultStatsResolved(player : Player, callback : (stats : { [string] : any }) -> nil) : RBXScriptSignal
+    local connection; connection = DefaultStatsResolved:Connect(function(resolvedPlayer, stats)
+        if resolvedPlayer == player then
+            callback(stats)
+            connection:Disconnect()
+        end
+    end)
+
+    if SessionData[player] then
+        connection:Disconnect() -- Disconnect immediately if already resolved
+        task.spawn(function()
+            callback(SessionData[Players.LocalPlayer])
+        end)
+    end
+    return connection
 end
 
 --= Initializers =--

--- a/src/Infra/Server/Modules/ServerClientInfoHandler.lua
+++ b/src/Infra/Server/Modules/ServerClientInfoHandler.lua
@@ -37,6 +37,7 @@ local ClientInfoChangedSignal = Signal.new()
 local DEFAULT_INFO = {
     device = "unknown",
     friendsOnline = 0,
+    preservedSessionId = "",
 }
 
 --= Variables =--

--- a/src/Infra/Server/Modules/ServerClientInfoHandler.lua
+++ b/src/Infra/Server/Modules/ServerClientInfoHandler.lua
@@ -37,7 +37,7 @@ local ClientInfoChangedSignal = Signal.new()
 local DEFAULT_INFO = {
     device = "unknown",
     friendsOnline = 0,
-    preservedSessionId = "",
+    preservedSessionData = {},
 }
 
 --= Variables =--

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -8,7 +8,10 @@
 	Updater.luau
 	
 	Description:
-		No description provided.
+		Handles updating the internal configurations of the Gamebeast SDK
+		based on the latest configurations received from the Gamebeast server.
+		It also manages experiment assignments and applies configurations
+		to players and the server.
 	
 --]]
 

--- a/src/Infra/Server/Modules/Utilities/init.luau
+++ b/src/Infra/Server/Modules/Utilities/init.luau
@@ -11,15 +11,12 @@ local MessagingServiceDebugCache = {} :: {[string] : number}
 local utilities = {}
 
 -- Central function for warning messages across SDK. Indicates Gamebeast as warning source and allows for output settings.
-utilities.GBWarn = function(message)
+utilities.GBWarn = function(...)
 	if DataCache:Get("Settings").sdkWarningsEnabled then
+		warn("GamebeastSDK:", ...)
 		if DataCache:Get("Settings").includeWarningStackTrace then
-			message = debug.traceback("GamebeastSDK: ".. message)
-		else
-			message = "GamebeastSDK: ".. message
+			warn("GamebeastSDK Traceback:", debug.traceback())
 		end
-		
-		warn(message)
 	end
 end
 

--- a/src/Infra/Server/Public/Configs.lua
+++ b/src/Infra/Server/Public/Configs.lua
@@ -5,7 +5,7 @@
     Configs.lua
     
     Description:
-        No description provided.
+        Server-side API for accessing and observing configuration data.
     
 --]]
 

--- a/src/Infra/Server/Public/Events.lua
+++ b/src/Infra/Server/Public/Events.lua
@@ -5,7 +5,7 @@
     Events.lua
     
     Description:
-        No description provided.
+        Public API for managing definined events.
     
 --]]
 

--- a/src/Infra/Server/Public/Markers.lua
+++ b/src/Infra/Server/Public/Markers.lua
@@ -5,7 +5,7 @@
     Markers.lua
     
     Description:
-        No description provided.
+        Server-side API for sending engagement markers.
     
 --]]
 

--- a/src/Infra/Shared/Modules/Cleaner.lua
+++ b/src/Infra/Shared/Modules/Cleaner.lua
@@ -5,7 +5,7 @@
     Cleaner.lua
     
     Description:
-        No description provided.
+        A utility module for managing and cleaning up objects and connections.
     
 --]]
 

--- a/src/Infra/Shared/Modules/GetRemote.luau
+++ b/src/Infra/Shared/Modules/GetRemote.luau
@@ -5,7 +5,7 @@
     GetRemote.luau
     
     Description:
-        No description provided.
+        A utility module for retrieving or creating remote functions or events.
     
 --]]
 

--- a/src/Infra/Shared/Modules/Schema.lua
+++ b/src/Infra/Shared/Modules/Schema.lua
@@ -1,0 +1,92 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+
+    Schema.lua
+    
+    Description:
+        No description provided.
+    
+--]]
+
+--= Root =--
+
+local Schema = {}
+Schema.__index = Schema
+
+--= Roblox Services =--
+
+--= Dependencies =--
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+--= Variables =--
+
+--= Internal Functions =--
+
+--= Constructor =--
+
+function Schema.new(structure : {[string] : {default : any | () -> any, type : string}})
+    local self = setmetatable({}, Schema)
+
+    self._structure = structure
+
+    return self
+end
+
+--= Methods =--
+
+function Schema:GetDefault() : {[string] : any}
+    local defaults = {}
+
+    for key, value in pairs(self._structure) do
+        if type(value.default) == "function" then
+            defaults[key] = value.default()
+        else
+            defaults[key] = value.default
+        end
+    end
+
+    return defaults
+end
+
+function Schema:GetDefaultForKey(key : string) : any
+    local field = self._structure[key]
+    if not field then
+        error("Key '" .. key .. "' does not exist in schema.")
+    end
+
+    if type(field.default) == "function" then
+        return field.default()
+    else
+        return field.default
+    end
+end
+
+function Schema:HasKey(key : string) : boolean
+    return self._structure[key] ~= nil
+end
+
+function Schema:Sanitize(data : {[string] : any})
+    for key, value in pairs(data) do
+        if self._structure[key] == nil then
+            data[key] = nil -- Remove keys not in the schema
+        end
+
+        if self._structure[key].type ~= value.type then
+            data[key] = nil -- Remove keys with incorrect type
+        end
+    end
+
+    return data
+end
+
+function Schema:Destroy()
+    -- Nothing to clean up in this case
+end
+
+return Schema

--- a/src/Infra/Shared/Modules/Signal/SignalConnection.lua
+++ b/src/Infra/Shared/Modules/Signal/SignalConnection.lua
@@ -4,7 +4,7 @@
     SignalConnection.lua
     
     Description:
-        No description provided.    
+        Emulates a RBXScriptConnection for signals, allowing for connection management
 --]]
 
 --= Root =--


### PR DESCRIPTION
This feature enables sessionId to be preserved through teleports to places within the same universe.

Now stats such as friendPlaytimePercent and sessionTime will account for total time spend in all places under an experience.

Additionally, teleports will no longer trigger login & logout markers.