### PR TITLE
feat: Custom API domain

### DIFF
--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -31,7 +31,7 @@ local MetaData = shared.GBMod("MetaData") ---@module MetaData
 local URL_SUFFIX = "/sdk"
 local ENDPOINTS = {
 	{ 
-		URL = "https://api.gamebeast.gg" .. URL_SUFFIX, -- http://localhost:3001 -- https://api.gamebeast.gg -- https://api.stage.gamebeast.gg
+		URL = "https://api.gamebeast.gg", -- http://localhost:3001 -- https://api.gamebeast.gg -- https://api.stage.gamebeast.gg
 		Requests = { -- NOTE: If you require URL parameters, use {param} in the route string. Example: "v1/servers/roblox/{serverId}"
 			["v1/markers"] = "POST",
 			["v1/requests"] = "GET",
@@ -70,7 +70,7 @@ local function GetEndpointForRequest(requestRoute : string) : (string?, string?)
 			end
 		end
 
-		return endpoint.URL, current["__method"]
+		return ((DataCache:Get("Settings").customUrl or endpoint.URL)..URL_SUFFIX), current["__method"]
 	end
 end
 

--- a/src/Infra/Types.luau
+++ b/src/Infra/Types.luau
@@ -5,6 +5,8 @@ type SDKSettings = {
 	includeWarningStackTrace : boolean,
 	-- Enables SDK debug messages for internal state changes, etc.
 	sdkDebugEnabled : boolean,
+	-- Custom URL for the SDK, if any.
+	customUrl : string | nil,
 }
 export type ServerSetupConfig = {
 	key : string | Secret,

--- a/src/init.lua
+++ b/src/init.lua
@@ -50,6 +50,7 @@ local DEFAULT_SETTINGS = {
 	sdkWarningsEnabled = true,
 	includeWarningStackTrace = false,
 	sdkDebugEnabled = false,
+	customUrl = nil, -- Custom domain for the SDK, if any
 }
 
 --= Object References =--


### PR DESCRIPTION
Allow developers to send markers to a custom domain instead of gamebeast.gg