### PR TITLE
feat: Retry mechanism for failed markers

### DIFF
--- a/src/Infra/Server/Modules/DatastoreBackup.lua
+++ b/src/Infra/Server/Modules/DatastoreBackup.lua
@@ -1,0 +1,80 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+    
+    DatastoreBackup.lua
+    
+    Description:
+        No description provided.
+    
+--]]
+
+--= Root =--
+local DatastoreBackup = { }
+
+--= Roblox Services =--
+local DataStoreService = game:GetService("DataStoreService")
+local RunService = game:GetService("RunService")
+
+--= Dependencies =--
+
+--= Types =--
+
+--= Constants =--
+local BACKUP_STORE_KEY = (RunService:IsStudio() and "Studio" or "") .. "_Gamebeast_Backup"
+
+--= Object References =--
+local BackupConfigStore = DataStoreService:GetDataStore(BACKUP_STORE_KEY)
+
+--= Variables =--
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+--= API Functions =--
+
+function DatastoreBackup:Set(key, value) : boolean
+    local success, errorMessage = pcall(function()
+        BackupConfigStore:SetAsync(key, value)
+    end)
+
+    if not success then
+        warn("Failed to save backup data for key '" .. key .. "': " .. tostring(errorMessage))
+    end
+
+    return success
+end
+
+function DatastoreBackup:Update(key, callback : (any) -> (any)) : boolean
+    local success, errorMessage = pcall(function()
+        BackupConfigStore:UpdateAsync(key, callback)
+    end)
+
+    if not success then
+        warn("Failed to update backup data for key '" .. key .. "': " .. tostring(errorMessage))
+    end
+
+    return success
+end
+
+function DatastoreBackup:Get(key) : (boolean, any)
+    local success, value = pcall(function()
+        return BackupConfigStore:GetAsync(key)
+    end)
+
+    if not success then
+        warn("Failed to retrieve backup data for key '" .. key .. "': " .. tostring(value))
+        return nil
+    end
+
+    return success, value
+end
+
+--= Initializers =--
+function DatastoreBackup:Init()
+    
+end
+
+--= Return Module =--
+return DatastoreBackup

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -25,11 +25,13 @@ local Cleaner = shared.GBMod("Cleaner")
 local MetaData = shared.GBMod("MetaData")
 local GetRemote = shared.GBMod("GetRemote")
 local Utilities = shared.GBMod("Utilities")
+local HostServer = shared.GBMod("HostServer") ---@module HostServer
 local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
+local Experiments = shared.GBMod("Experiments") ---@module Experiments
+local FailedMarkers = shared.GBMod("FailedMarkers") ---@module FailedMarkers
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local LocalizationCache = shared.GBMod("LocalizationCache") ---@module LocalizationCache
 local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
-local Experiments = shared.GBMod("Experiments") ---@module Experiments
 
 --= Types =--
 
@@ -41,14 +43,6 @@ local CLIENT_DATA_TIMEOUT = RunService:IsStudio() and 10 or 45
 local MAX_EVENT_QUEUE_SIZE = 1000
 local QUEUE_CHECK_TIME = 5
 local MAX_EVENT_REPORT_TIME = 10
-local SYSTEM_MARKERS = {
-	["Logout"] = true,
-	["Login"] = true,
-	["Purchase"] = true,
-	["Chat"] = true,
-	--["GBClientPerformance"] = true,
-	--["GBServerPerformance"] = true,
-}
 local ALLOWED_VALUE_TYPES = {
 	["string"] = true,
 	["number"] = true,
@@ -89,20 +83,65 @@ local function EncodeVector3(vec)
 	return vectorArray
 end
 
+local function isMarkerDataValid(markerData : {}) : boolean
+	for _, value in markerData do
+		local valueType = type(value)
+		if ALLOWED_VALUE_TYPES[valueType] == nil then
+			return false
+		end
+
+		if valueType == "table" and not isMarkerDataValid(value) then
+			return false
+		end
+	end
+
+	return true
+end
+
+local function AddMarker(marker)
+	table.insert(MarkerQueue, marker)
+	
+	-- If marker queue size limit reached then send batch
+	if #MarkerQueue >= MAX_EVENT_QUEUE_SIZE then
+		EngagementMarkers:SendMarkers()
+	end
+end
+
 --= API Functions =--
 
 -- Send batch to GB
-function EngagementMarkers:SendMarkers()
-	if #MarkerQueue > 0 then
+function EngagementMarkers:SendMarkers(queue : {any}?) : (boolean, {[string] : any}?)
+	local isCustomQueue = queue ~= nil
+	queue = queue or MarkerQueue
+	if #queue > 0 then
 		LastEventReportTime = tick()
 		
 		local data = {
-			markers = MarkerQueue
+			markers = queue
 		}
 
-		MarkerQueue = {}
-		GBRequests:GBRequest("v1/markers", data)
+		if isCustomQueue then
+			MarkerQueue = {}
+		end
+		
+		local success, errorBody = GBRequests:GBRequestAsync("v1/markers", data)
+		if not success and isCustomQueue == false then
+			-- If request failed, add markers back to queue for retry
+			for _, marker in data.markers do
+				if not isMarkerDataValid(marker) then
+					Utilities.GBWarn("Invalid marker data detected, skipping marker")
+					continue
+				end
+
+				FailedMarkers:AddMarker(marker)
+			end
+
+			Utilities.GBWarn("Failed to send engagement markers to Gamebeast. Markers will be retried later.")
+		end
+		return success, errorBody
 	end
+
+	return true
 end
 
 -- Core function, should be used internally by SDK rather than fireMarker
@@ -181,15 +220,6 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		},
 	}
 
-	local function addMarker()
-		table.insert(MarkerQueue, entry)
-		
-		-- If marker queue size limit reached then send batch
-		if #MarkerQueue >= MAX_EVENT_QUEUE_SIZE then
-			EngagementMarkers:SendMarkers()
-		end
-	end
-
 	--[[
 		Ensure markers are sent with all required data.
 	]]
@@ -221,7 +251,7 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 				entry.sessionId = GetSessionIdForPlayer(player)
 			end
 
-			addMarker()
+			AddMarker(entry)
 
 			-- Remove from waiting list if it exists
 			if not shutdown then
@@ -310,16 +340,6 @@ end
 --= Initializers =--
 function EngagementMarkers:Init()
 	--NOTE: Firing markers from client is disabled. Shifting responsibility to the developer for security.
-	--[[ Handle client requests through API module
-	FireMarkerEvent.OnServerEvent:Connect(function(player, markerType, value, metaData)
-		if metaData then
-			metaData.player = player
-		else
-			metaData = {player = player}
-		end
-
-		EngagementMarkers:_createMarker("client", markerType, value, metaData)
-	end)]]
 
 	Players.ChildRemoved:Connect(function(player)
 		task.defer(function()
@@ -334,11 +354,66 @@ function EngagementMarkers:Init()
 			local lastReportElapsed = tick() - LastEventReportTime
 
 			if lastReportElapsed >= MAX_EVENT_REPORT_TIME then
-				EngagementMarkers:SendMarkers()
+				self:SendMarkers()
 			end
 			
 			if InternalConfigs:WaitForConfigsReady() then
 				MAX_EVENT_REPORT_TIME = InternalConfigs:GetActiveConfig("GBConfigs")["GBRates"]["EngagementMarkers"]
+			end
+		end
+	end)
+
+	task.spawn(function()
+		while task.wait(10) do
+			if not HostServer:IsHostServer() then
+				-- If not host, we don't need to send markers
+				continue
+			end
+
+			local processedCount = FailedMarkers:Get(1000, function(markers)
+				if #markers > 0 then
+					-- If we have markers to send, send them
+					local validMarkers = {}
+					local count = 0
+					for _, marker in markers do
+						if not isMarkerDataValid(marker) then
+							Utilities.GBWarn("Invalid marker data detected, skipping marker")
+							continue
+						end
+
+						table.insert(validMarkers, marker)
+						count += 1
+					end
+
+					local success, errorBody = self:SendMarkers(validMarkers)
+					if not success and errorBody and errorBody.rejectedMarkers then
+						if errorBody.ingestedMarkersCount then
+							return true -- Markers were sent, but were likely invalid for some reason.
+						end
+						
+						--[[ Logic to handle rejected markers if needed
+						local rejectedMarkerIds = {}
+						for _, rejectedMarkerInfo in errorBody.rejectedMarkers do
+							rejectedMarkerIds[rejectedMarkerInfo.marker.markerId] = true
+						end
+
+						for mIndex=1, count do
+							local markerId = validMarkers[mIndex].markerId
+							if rejectedMarkerIds[markerId] then
+								-- Do something with the rejected marker?
+							else
+								print("Successfully sent marker:", markerId)
+							end
+						end
+						]]
+					end
+
+					return success
+				end
+			end)
+
+			if processedCount <= 0 then
+				task.wait(55) -- Wait longer if no markers to process
 			end
 		end
 	end)
@@ -348,7 +423,9 @@ function EngagementMarkers:Init()
 			data.resolved(true)
 		end
 
-		EngagementMarkers:SendMarkers()
+		self:SendMarkers()
+
+		FailedMarkers:ForceSavePending()
 	end)
 end
 

--- a/src/Infra/Server/Modules/FailedMarkers.lua
+++ b/src/Infra/Server/Modules/FailedMarkers.lua
@@ -1,0 +1,224 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+    
+    FailedMarkers.lua
+    
+    Description:
+        - Ordered datastore holds keys for batches of failed markers.
+        - Normal datastore holds the markers themselves.
+        - 2 requests per batch. One to delete the ordered key, and one to delete the markers.
+        Enum.DataStoreRequestType.SetIncrementSortedAsync
+        Enum.DataStoreRequestType.SetIncrementAsync
+--]]
+
+--= Root =--
+local FailedMarkers = { }
+
+--= Roblox Services =--
+local HttpService = game:GetService("HttpService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local DataStoreService = game:GetService("DataStoreService")
+
+--= Dependencies =--
+
+local Utilities = shared.GBMod("Utilities") ---@module Utilities
+
+--= Types =--
+
+--= Object References =--
+
+local MarkersDataStore = DataStoreService:GetDataStore("GB_FailedMarkers")
+local OrderedMarkersDataStore = DataStoreService:GetOrderedDataStore("GB_FailedMarkers")
+
+--= Constants =--
+
+local MAX_RETRY_COUNT = 3 -- Maximum number of retries for saving markers
+local MAX_QUEUE_SIZE = 400
+local MAX_MARKERS_PER_BATCH = 1000 -- Maximum markers per batch
+
+--= Variables =--
+
+local RetryQueue = {} :: {{retryCount : number, markers : {any}}}
+local MarkersPendingBatch = {} :: {any}
+local MarkersPendingCount = 0
+
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+--= API Functions =--
+
+function FailedMarkers:CanAfford() : boolean
+    local budget = DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.SetIncrementAsync)
+    local sortedBudget = DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.SetIncrementSortedAsync)
+    local getSortedBudget = DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.GetSortedAsync)
+
+    -- Check if we have enough budget for both requests
+    return getSortedBudget > 1 and budget >= 20 and sortedBudget >= 12
+end
+
+-- Uses Budget of 1 Ordered and 1 Normal
+function FailedMarkers:Save(markers : {any}, isRetry : boolean?) : boolean
+    local key = HttpService:GenerateGUID(false)
+    local markerCount = #markers
+    if markerCount > MAX_MARKERS_PER_BATCH then
+        Utilities.GBWarn("Too many markers to save in one batch:", markerCount)
+        return false
+    end
+
+    local success, errorMessage = pcall(function()
+        if not self:CanAfford() then
+            error("Not enough budget to save markers")
+        end
+        -- Add the key to the ordered datastore
+        OrderedMarkersDataStore:SetAsync(key, markerCount)
+        
+        -- Save the markers to the normal datastore
+        MarkersDataStore:SetAsync(key, markers)
+    end)
+
+    if not success then
+        --Utilities.GBWarn("Failed to save markers:", errorMessage)
+        if not isRetry then
+            if #RetryQueue + 1 >= MAX_QUEUE_SIZE then
+                -- If the queue is full, remove the oldest item
+                table.remove(RetryQueue, 2)
+            end
+
+            table.insert(RetryQueue, {
+                retryCount = 0,
+                markers = markers
+            })
+        end
+        return false
+    end
+
+    return true
+end
+
+-- Uses max budget of 1 GetSorted, 20 SetIncrementAsync, and 10 SetIncrementSortedAsync
+function FailedMarkers:Get(maxMarkers : number, callback : (({any}) -> boolean)?) : number
+    if not self:CanAfford() then
+        return {}
+    end
+
+    local keyPageSuccess, keyPages = pcall(function()
+        return OrderedMarkersDataStore:GetSortedAsync(false, 10) -- Get the first 10 keys
+    end)
+
+    if not keyPageSuccess then
+        Utilities.GBWarn("Failed to retrieve keys from OrderedMarkersDataStore:", keyPages)
+        return {}
+    end
+
+    local markers = {}
+    local count = 0
+    local toDelete = {}
+
+    for _, kvPair in pairs(keyPages:GetCurrentPage()) do
+        if kvPair.value + count > maxMarkers then
+            -- If adding this batch exceeds the maxMarkers limit, break
+            break
+        end
+
+
+        local success, data = pcall(function()
+            return MarkersDataStore:GetAsync(kvPair.key)
+        end)
+
+        if data == nil then
+            -- If the data is nil, it means the key was deleted or doesn't exist
+            continue
+        end
+
+    
+        table.insert(toDelete, kvPair.key)
+
+        if success and data then
+            for _, marker in pairs(data) do
+                table.insert(markers, marker)
+            end
+
+            count += kvPair.value
+        else
+            Utilities.GBWarn("Failed to retrieve markers for key:", kvPair.key, "Error:", data)
+        end
+    end
+
+
+    local success = callback(markers)
+    if success then
+        for _, key in toDelete do
+            local deleteSuccess, deleteError = pcall(function()
+                OrderedMarkersDataStore:RemoveAsync(key)
+                MarkersDataStore:RemoveAsync(key)
+            end)
+
+            if not deleteSuccess then
+                Utilities.GBWarn("Failed to delete key from OrderedMarkersDataStore:", key, "Error:", deleteError)
+            end
+        end
+    end
+
+
+    return count
+end
+
+function FailedMarkers:ForceSavePending()
+    if MarkersPendingCount > 0 then
+        -- If there are pending markers, save them immediately
+        local toSave = MarkersPendingBatch
+        MarkersPendingBatch = {}
+        MarkersPendingCount = 0
+
+        self:Save(toSave)
+    end
+end
+
+function FailedMarkers:AddMarker(marker : {[string] : any})
+    MarkersPendingCount += 1
+    MarkersPendingBatch[MarkersPendingCount] = marker
+    if MarkersPendingCount >= MAX_MARKERS_PER_BATCH then
+        -- If we have enough markers, save them
+        local toSave = MarkersPendingBatch
+        MarkersPendingBatch = {}
+        MarkersPendingCount = 0
+
+        self:Save(toSave)
+    end
+end
+
+--= Initializers =--
+function FailedMarkers:Init()
+    task.spawn(function()
+        while true do
+            if #RetryQueue > 0 then
+                if self:CanAfford() then
+                    -- If budget is low, wait before retrying
+                    task.wait(5)
+                    continue
+                end
+
+
+                local retryItem = table.remove(RetryQueue, 1)
+                -- Attempt to save the markers again
+                if retryItem.retryCount < MAX_RETRY_COUNT then
+                    retryItem.retryCount += 1
+                    local success = self:Save(retryItem.markers, true)
+                    if not success then
+                        table.insert(RetryQueue, retryItem) -- Reinsert the item for retry
+                        task.wait(5)
+                    end
+                else
+                    Utilities.GBWarn("Failed to save markers after maximum retries")
+                end
+            end
+            task.wait(2)
+        end
+    end)
+end
+
+--= Return Module =--
+return FailedMarkers

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -38,8 +38,6 @@ local ENDPOINTS = {
 			["v1/requests/completed"] = "POST",
 			["v1/requests/started"] = "PUT",
 			["v1/configurations"] = "GET",
-			["v1/heatmap"] = "POST",
-			["v1/heatmap/waypoint"] = "POST",
 			["v1/latest/version?platform=roblox"] = "GET",
 			["v1/experiments/assignments"] = "POST",
 			["v1/servers/roblox/{serverId}"] = "POST"
@@ -116,8 +114,15 @@ end
 
 --YEILDS 
 function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any}, maxRetries : number?) : (boolean, any?)
-	RequestProcessingCount += 1
 	local GBDomain, requestMethod = GetEndpointForRequest(requestRoute)
+	
+	if not GBDomain or not requestMethod then
+		Utilities.GBWarn("Invalid request route:", requestRoute)
+		return false, nil
+	end
+
+	RequestProcessingCount += 1
+
 	local requestBody
 	args = args or {}
 

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -19,25 +19,22 @@
 local Updater = { }
 
 --= Roblox Services =--
-local DataStoreService = game:GetService("DataStoreService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
 local RunService = game:GetService("RunService")
 
 --= Dependencies =--
 
 local GBRequests = shared.GBMod("GBRequests")
-local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module EngagementMarkers
 local Experiments = shared.GBMod("Experiments") ---@module Experiments
 local Utilities = shared.GBMod("Utilities")
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local Signal = shared.GBMod("Signal")
+local DatatstoreBackup = shared.GBMod("DatastoreBackup") ---@module DatastoreBackup
 local MetaData = shared.GBMod("MetaData") ---@module MetaData
 
 --= Types =--
 
 --= Constants =--
-
-local BACKUP_STORE_KEY = (RunService:IsStudio() and "Studio" or "") .. "GBConfigBackup"
 
 --[[
 	When config is being applied, this controls the maximum amount of seconds
@@ -50,8 +47,6 @@ local BACKUP_STORE_KEY = (RunService:IsStudio() and "Studio" or "") .. "GBConfig
 local MAX_INITIAL_EXPERIMENT_ASSIGNMENT_WAIT_TIME = 5
 
 --= Object References =--
-
-local BackupConfigStore = DataStoreService:GetDataStore(BACKUP_STORE_KEY)
 
 --= Variables =--
 
@@ -146,9 +141,7 @@ end
 
 -- In the unlikely case GB is down, fall back on Roblox datastores
 function Updater:GetBackupConfigs()
-	local configs, success = Utilities.promiseReturn(2, function()
-		return BackupConfigStore:GetAsync(BACKUP_STORE_KEY)
-	end)
+	local success, configs = DatatstoreBackup:Get("Configs")
 	
 	if not success then
 		Utilities.GBWarn("Couldn't get configs from backup. Attempting to re-establish connection with Gamebeast...")
@@ -168,9 +161,7 @@ function Updater:SaveConfigsToBackup(newConfigs)
 	local newBackupConfigs = Utilities.recursiveCopy(newConfigs)
 	newBackupConfigs.GBConfigs.Experiments = nil
 
-	Utilities.promiseReturn(1, function()
-		BackupConfigStore:SetAsync(BACKUP_STORE_KEY, newBackupConfigs)
-	end)
+	DatatstoreBackup:Set("Configs", newBackupConfigs)
 end
 
 


### PR DESCRIPTION
Uses Roblox datastore to hold onto markers that failed to make it into Gamebeast, helping to prevent data loss in the event of an outage. 