### PR TITLE
v0.6.0

### DIFF
--- a/.github/workflows/createSdkSource.js
+++ b/.github/workflows/createSdkSource.js
@@ -1,0 +1,59 @@
+const Redis = require('ioredis');
+const fs = require('fs');
+const path = require('path');
+
+const redis = new Redis();
+
+redis.on('connect', () => console.log('Redis connected'));
+redis.on('error', (err) => {
+  console.error('Redis error:', err);
+  process.exit(1);
+});
+
+
+function parseDirectory(dirPath) {
+  const result = {};
+
+  const items = fs.readdirSync(dirPath, { withFileTypes: true });
+
+  for (const item of items) {
+    const fullPath = path.join(dirPath, item.name)
+    
+    console.log(`Processing: ${fullPath}`);
+
+    if (item.isDirectory()) {
+      result[item.name] = parseDirectory(fullPath);
+    } else if (item.isFile() && (item.name.endsWith('.lua') || item.name.endsWith('.luau'))) {
+      const content = fs.readFileSync(fullPath, 'utf-8');
+      result[item.name] = content;
+    }
+  }
+
+  return result;
+}
+
+function getVersion(fileText) {
+  const versionMatch = fileText.match(/version\s*=\s*['"]([^'"]+)['"]/);
+  return versionMatch ? versionMatch[1] : 'unknown';
+}
+
+(async () => {
+  const rootDir = process.cwd() + "/src";
+  const parsed = parseDirectory(rootDir);
+  const version = getVersion(parsed.Infra["MetaData.lua"]);
+  const output = JSON.stringify({ worked: true, version: version, source: parsed });
+  console.log('Payload size (bytes):', Buffer.byteLength(output));
+
+  try {
+    const result = await redis.set("latestSdkSourceCodeV2", output);
+    console.log('Redis SET result:', result);
+
+    const versionSetResult = await redis.set("latestSdkVersionV2", version);
+    console.log("Redis version SET result:", versionSetResult);
+
+    process.exit(0);
+  } catch (err) {
+    console.error('Redis SET failed:', err);
+    process.exit(1);
+  }
+})();

--- a/.github/workflows/sdk-redis-keys.yml
+++ b/.github/workflows/sdk-redis-keys.yml
@@ -1,0 +1,62 @@
+name: Update SDK Redis Keys
+
+on:
+  workflow_dispatch:
+    inputs:
+      target:
+        type: choice
+        description: 'Deployment target'
+        required: true
+        default: 'dev'
+        options:
+          - dev
+          - stage
+          - prod
+
+jobs:
+  update-redis-keys:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v2"
+        with:
+          project_id: "x-cycling-414419"
+          workload_identity_provider: "projects/577495761779/locations/global/workloadIdentityPools/github-actions/providers/github-actions-provider"
+          service_account: "service-account-github-act-764@x-cycling-414419.iam.gserviceaccount.com"
+
+      - name: Setup Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: "gke-gcloud-auth-plugin,beta"
+
+      - name: Verify gcloud authentication
+        run: |
+          gcloud auth list
+
+      - name: Set up SSH SOCKS proxy
+        env:
+          REDIS_HOST: "${{ github.event.inputs.target == 'stage' && '10.128.0.62' || github.event.inputs.target == 'prod' && '10.128.15.192' || '10.128.0.114' }}"
+          PROXY_CLUSTER: "${{ github.event.inputs.target == 'stage' && 'proxy-stage-cluster' || github.event.inputs.target == 'prod' && 'proxy-prod-cluster' || 'proxy-dev-cluster' }}"
+        run: |
+          gcloud beta compute ssh $PROXY_CLUSTER \
+            --project x-cycling-414419 \
+            --zone us-central1-a \
+            --tunnel-through-iap \
+            --ssh-flag="-4 -L 6379:$REDIS_HOST:6379 -N -q -f"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Update Redis
+        run: npm install ioredis && node .github/workflows/createSdkSource.js

--- a/src/Infra/Client/Modules/ClientConfigs.lua
+++ b/src/Infra/Client/Modules/ClientConfigs.lua
@@ -110,7 +110,7 @@ function ClientConfigs:OnChanged(targetConfig : string | {string}, callback : (n
     end)
 end
 
-function ClientConfigs:OnReady(callback : (configs : any) -> ()) : RBXScriptSignal
+function ClientConfigs:OnReady(callback : (configs : any) -> ()) : RBXScriptConnection
     return ConfigReadySignal:Connect(function()
         callback(CachedConfigs)
     end)

--- a/src/Infra/Client/Modules/ClientConfigs.lua
+++ b/src/Infra/Client/Modules/ClientConfigs.lua
@@ -5,7 +5,7 @@
     ClientConfigs.lua
     
     Description:
-        No description provided.
+        Internal module for managing client-side configuration data.
     
 --]]
 

--- a/src/Infra/Client/Modules/ClientFriendHandler.lua
+++ b/src/Infra/Client/Modules/ClientFriendHandler.lua
@@ -1,0 +1,102 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+    
+    ClientFriendHandler.lua
+    
+    Description:
+        No description provided.
+    
+--]]
+
+
+--= Root =--
+local ClientFriendHandler = { }
+
+--= Roblox Services =--
+
+local Players = game:GetService("Players")
+
+--= Dependencies =--
+
+local ClientInfoHandler = shared.GBMod("ClientInfoHandler") ---@module ClientInfoHandler
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+--= Variables =--
+
+local FriendCache = {} :: {[number] : boolean}
+local FriendsOnline = 0
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+local function UpdateFriendCache()
+    local foundFriendsOnline = 0
+    local success, errorMessage = pcall(function() -- Minimizes internal HTTP requests
+        local friendsList = Players:GetFriendsAsync(Players.LocalPlayer.UserId)
+        
+        while true do
+            local list = friendsList:GetCurrentPage()
+            for _, friend in ipairs(list) do
+                if Players:GetPlayerByUserId(friend.Id) then
+                    foundFriendsOnline += 1
+                end
+                FriendCache[friend.Id] = true
+            end
+
+            if friendsList.IsFinished then
+                break
+            else
+                friendsList:AdvanceToNextPageAsync()
+            end
+        end
+    end)
+
+    -- client only sends initial total time and friends online count
+
+    local hasFriendsOnline = ClientInfoHandler:GetClientInfo("hasFriendsOnline") or false
+
+    if hasFriendsOnline == true and foundFriendsOnline <= 0 then
+        ClientInfoHandler:UpdateClientInfo("totalFriendPlaytime", (ClientInfoHandler:GetClientInfo("totalFriendPlaytime") or 0) + os.clock() - (ClientInfoHandler:GetClientInfo("friendClockStart")))
+    elseif foundFriendsOnline > 0 and hasFriendsOnline == false then
+        ClientInfoHandler:UpdateClientInfo("friendClockStart", os.clock())
+    end
+
+    FriendsOnline = foundFriendsOnline
+    ClientInfoHandler:UpdateClientInfo("hasFriendsOnline", FriendsOnline > 0)
+
+    return success, errorMessage
+end
+
+--= API Functions =--
+
+--= Initializers =--
+function ClientFriendHandler:Init()
+    task.spawn(function()
+        Players.PlayerAdded:Connect(function(player : Player)
+            if FriendCache[player.UserId] then
+                FriendsOnline += 1
+            end
+        end)
+
+        Players.PlayerRemoving:Connect(function(player : Player)
+            if FriendCache[player.UserId] then
+                FriendsOnline -= 1
+            end
+        end)
+
+        UpdateFriendCache()
+        while task.wait(60 * 10) do
+            UpdateFriendCache()
+        end
+    end)
+end
+
+--= Return Module =--
+return ClientFriendHandler

--- a/src/Infra/Client/Modules/ClientInfoHandler.lua
+++ b/src/Infra/Client/Modules/ClientInfoHandler.lua
@@ -5,7 +5,7 @@
     ClientInfoHandler.lua
     
     Description:
-        No description provided.
+        Module for managing reported client information and product pricing.
     
 --]]
 
@@ -15,13 +15,11 @@ local ClientInfoHandler = { }
 --= Roblox Services =--
 
 local MarketplaceService = game:GetService("MarketplaceService")
-local Players = game:GetService("Players")
-local UserInputService = game:GetService("UserInputService")
-local VRService = game:GetService("VRService")
 
 --= Dependencies =--
 
 local GetRemote = shared.GBMod("GetRemote")
+local ClientSessionPreservation = shared.GBMod("ClientSessionPreservation") ---@module ClientSessionPreservation
 
 --= Types =--
 
@@ -32,22 +30,34 @@ local ClientProductPriceRemote = GetRemote("Function", "GetProductPrice")
 
 --= Constants =--
 
+local REQUIRED_KEYS = {
+    device = true,
+    deviceSubType = true,
+    inputType = true,
+}
+
 --= Variables =--
 
 local ProductInfoCache = {} :: {[number] : {PriceInRobux : number}}
 local CurrentClientInfoCache = {} :: {[string] : any}
-local FriendCache = {} :: {[number] : boolean}
-local FriendsOnline = 0
 local PendingUpdate = false
-local CurrentInputType = nil
 
 --= Public Variables =--
 
 --= Internal Functions =--
 
-local function UpdateClientInfo(key : string, value : any, force : boolean?)
-    if CurrentClientInfoCache[key] ~= value or force then
+--= API Functions =--
+
+function ClientInfoHandler:UpdateClientInfo(key : string, value : any)
+    if CurrentClientInfoCache[key] ~= value then
         CurrentClientInfoCache[key] = value
+        ClientSessionPreservation:UpdateStoredData(key, value)
+
+        for key in REQUIRED_KEYS do
+            if not CurrentClientInfoCache[key] then
+                return -- Will not send signal that client info is ready until all required keys are set
+            end
+        end
 
         if PendingUpdate then
             return
@@ -61,149 +71,15 @@ local function UpdateClientInfo(key : string, value : any, force : boolean?)
     end
 end
 
-local function UpdateFriendCache()
-    local foundFriendsOnline = 0
-    local success, errorMessage = pcall(function() -- Minimizes internal HTTP requests
-        local friendsList = Players:GetFriendsAsync(Players.LocalPlayer.UserId)
-        
-        repeat
-            local list = friendsList:GetCurrentPage()
-            for _, friend in ipairs(list) do
-                if Players:GetPlayerByUserId(friend.Id) then
-                    foundFriendsOnline += 1
-                end
-                FriendCache[friend.Id] = true
-            end
-
-            if not friendsList.IsFinished then
-                friendsList:AdvanceToNextPageAsync()
-            end
-        until friendsList.IsFinished
-    end)
-
-    FriendsOnline = foundFriendsOnline
-    UpdateClientInfo("friendsOnline", FriendsOnline)
+function ClientInfoHandler:GetClientInfo(key : string) : any
+    return CurrentClientInfoCache[key]
 end
-
-local function DetermineInputTypeString(InputEnum) 
-    if InputEnum == Enum.UserInputType.Keyboard then
-        return "keyboard"
-    elseif InputEnum == Enum.UserInputType.Touch then
-        return "touch"
-    elseif string.match(tostring(InputEnum),"Gamepad") then
-        return "gamepad"
-    end
-end
-
---= API Functions =--
-
-function ClientInfoHandler:GetDeviceType() : (string, string)
-    -- Determine device type
-    local deviceType = "unknown"
-    if UserInputService.VREnabled or VRService.VREnabled then
-        deviceType = "vr"
-    elseif UserInputService.TouchEnabled and not UserInputService.KeyboardEnabled then
-		deviceType = "mobile"
-	elseif UserInputService.GamepadEnabled and not UserInputService.KeyboardEnabled then
-		deviceType = "console"
-	elseif UserInputService.KeyboardEnabled then
-		deviceType = "pc"
-	end
-
-    -- Determine device subtype
-    local deviceSubType = "unknown"
-    if deviceType == "mobile" then
-        local camera = workspace.CurrentCamera
-        if camera then
-            local longestSide = math.max(camera.ViewportSize.X, camera.ViewportSize.Y)
-            local shortestSide = math.min(camera.ViewportSize.X, camera.ViewportSize.Y)
-            local aspectRatio = longestSide / shortestSide
-            if aspectRatio > 1.8 then
-                deviceSubType = "phone"
-            elseif aspectRatio <= 1.7 then
-                deviceSubType = "tablet"
-            else -- Devices in this range can be either phone or tablet equally. Older devices share the 16:9 aspect ratio.
-                deviceSubType = "phone" -- We'll assume phone for now, since phone users are more common.
-            end
-        end
-    elseif deviceType == "console" then
-        local imageUrl = UserInputService:GetImageForKeyCode(Enum.KeyCode.ButtonX)
-        if string.find(imageUrl, "Xbox") then
-            deviceSubType = "xbox"
-        elseif string.find(imageUrl, "PlayStation") then
-            deviceSubType = "playstation"
-        else
-            deviceSubType = "unknown"
-        end
-    elseif deviceType == "vr" then
-        deviceSubType = "unknown" -- No reliable way to determine VR headset type in Roblox.
-    elseif deviceType == "pc" then
-        deviceSubType = "unknown" -- No reliable way to determine PC type in Roblox
-    end
-
-    return deviceType, deviceSubType
-end
-
-
 
 --= Initializers =--
-function ClientInfoHandler:Init()
-    local deviceType, deviceSubType = self:GetDeviceType()
-    UpdateClientInfo("deviceSubType", deviceSubType)
-    UpdateClientInfo("device", deviceType, true)
-
-    -- Input type detection
-
-    local function inputTypeChanged(inputType : string)
-        if CurrentInputType ~= inputType then
-            CurrentInputType = inputType
-            UpdateClientInfo("inputType", CurrentInputType)
-        end
+do
+    for key, value in ClientSessionPreservation:GetStoredData() do
+        ClientInfoHandler:UpdateClientInfo(key, value)
     end
-
-    if UserInputService.GamepadEnabled then
-        inputTypeChanged("gamepad")
-    elseif UserInputService.TouchEnabled then
-        inputTypeChanged("touch")
-    else
-        inputTypeChanged("keyboard")
-    end
-
-    --// Detect CurrentInputType changes from 'LastInputType'
-    UserInputService.LastInputTypeChanged:Connect(function(lastType)
-        local newType = DetermineInputTypeString(lastType)
-        if newType and newType ~= CurrentInputType then
-            inputTypeChanged(newType)
-        end
-    end)
-
-     UserInputService.InputChanged:Connect(function(InputObject)
-        if InputObject.UserInputType == Enum.UserInputType.MouseMovement then
-            inputTypeChanged("keyboard")
-        end
-    end)
-
-    -- Friends online
-    task.spawn(function()
-        Players.PlayerAdded:Connect(function(player : Player)
-            if FriendCache[player.UserId] then
-                FriendsOnline += 1
-                UpdateClientInfo("friendsOnline", FriendsOnline)
-            end
-        end)
-
-        Players.PlayerRemoving:Connect(function(player : Player)
-            if FriendCache[player.UserId] then
-                FriendsOnline -= 1
-                UpdateClientInfo("friendsOnline", FriendsOnline)
-            end
-        end)
-
-        UpdateFriendCache()
-        while task.wait(60 * 10) do
-            UpdateFriendCache()
-        end
-    end)
 
     -- Geographic pricing
     ClientProductPriceRemote.OnClientInvoke = function(productId : number, productType : Enum.InfoType) : number
@@ -222,6 +98,10 @@ function ClientInfoHandler:Init()
             return nil
         end
     end
+
+    ClientInfoRemote.OnClientEvent:Connect(function(key : string, value : any)
+        ClientInfoHandler:UpdateClientInfo(key, value)
+    end)
 end
 
 --= Return Module =--

--- a/src/Infra/Client/Modules/ClientInputHandler.lua
+++ b/src/Infra/Client/Modules/ClientInputHandler.lua
@@ -1,0 +1,148 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+	All rights reserved.
+
+    ClientInputHandler.luau
+
+    Description:
+        Tracks the current input type and device type of the client.
+]]
+
+--= Root =--
+local ClientInputHandler = { }
+
+--= Roblox Services =--
+
+local UserInputService = game:GetService("UserInputService")
+local VRService = game:GetService("VRService")
+
+--= Dependencies =--
+
+local ClientInfoHandler = shared.GBMod("ClientInfoHandler") ---@module ClientInfoHandler
+local Signal = shared.GBMod("Signal") ---@module Signal
+
+--= Types =--
+
+--= Object References =--
+
+local InputTypeChangedSignal = Signal.new()
+
+--= Constants =--
+
+--= Variables =--
+
+local CurrentInputType = nil
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+local function DetermineInputTypeString(inputEnum) 
+    if inputEnum == Enum.UserInputType.Keyboard then
+        return "keyboard"
+    elseif inputEnum == Enum.UserInputType.Touch then
+        return "touch"
+    elseif string.match(tostring(inputEnum),"Gamepad") then
+        return "gamepad"
+    end
+end
+--= API Functions =--
+
+--= API Functions =--
+
+function ClientInputHandler:GetDeviceType() : (string, string)
+    -- Determine device type
+    local deviceType = "unknown"
+    if UserInputService.VREnabled or VRService.VREnabled then
+        deviceType = "vr"
+    elseif UserInputService.TouchEnabled and not UserInputService.KeyboardEnabled then
+		deviceType = "mobile"
+	elseif UserInputService.GamepadEnabled and not UserInputService.KeyboardEnabled then
+		deviceType = "console"
+	elseif UserInputService.KeyboardEnabled then
+		deviceType = "pc"
+	end
+
+    -- Determine device subtype
+    local deviceSubType = "unknown"
+    if deviceType == "mobile" then
+        local camera = workspace.CurrentCamera
+        if camera then
+            local longestSide = math.max(camera.ViewportSize.X, camera.ViewportSize.Y)
+            local shortestSide = math.min(camera.ViewportSize.X, camera.ViewportSize.Y)
+            local aspectRatio = longestSide / shortestSide
+            if aspectRatio > 1.8 then
+                deviceSubType = "phone"
+            elseif aspectRatio <= 1.7 then
+                deviceSubType = "tablet"
+            else -- Devices in this range can be either phone or tablet equally. Older devices share the 16:9 aspect ratio.
+                deviceSubType = "phone" -- We'll assume phone for now, since phone users are more common.
+            end
+        end
+    elseif deviceType == "console" then
+        local imageUrl = UserInputService:GetImageForKeyCode(Enum.KeyCode.ButtonX)
+        if string.find(imageUrl, "Xbox") then
+            deviceSubType = "xbox"
+        elseif string.find(imageUrl, "PlayStation") then
+            deviceSubType = "playstation"
+        else
+            deviceSubType = "unknown"
+        end
+    elseif deviceType == "vr" then
+        deviceSubType = "unknown" -- No reliable way to determine VR headset type in Roblox.
+    elseif deviceType == "pc" then
+        deviceSubType = "unknown" -- No reliable way to determine PC type in Roblox
+    end
+
+    return deviceType, deviceSubType
+end
+
+function ClientInputHandler:OnInputTypeChanged(callback : (string) -> ()) : RBXScriptConnection
+    return InputTypeChangedSignal:Connect(callback)
+end
+
+function ClientInputHandler:GetCurrentInputType() : string
+    if not CurrentInputType then
+        if UserInputService.GamepadEnabled then
+            CurrentInputType = "gamepad"
+        elseif UserInputService.TouchEnabled then
+            CurrentInputType = "touch"
+        else
+            CurrentInputType = "keyboard"
+        end
+    end
+    return CurrentInputType
+end
+
+--= Initializers =--
+function ClientInputHandler:Init()
+    local function inputTypeChanged(inputType : string)
+        if CurrentInputType ~= inputType then
+            CurrentInputType = inputType
+            InputTypeChangedSignal:Fire(CurrentInputType)
+            ClientInfoHandler:UpdateClientInfo("inputType", CurrentInputType)
+        end
+    end
+
+    local deviceType, deviceSubType = self:GetDeviceType()
+    ClientInfoHandler:UpdateClientInfo("inputType", ClientInputHandler:GetCurrentInputType())
+    ClientInfoHandler:UpdateClientInfo("deviceSubType", deviceSubType)
+    ClientInfoHandler:UpdateClientInfo("device", deviceType)
+
+    --// Detect CurrentInputType changes from 'LastInputType'
+    UserInputService.LastInputTypeChanged:Connect(function(lastType)
+        local newType = DetermineInputTypeString(lastType)
+        if newType and newType ~= CurrentInputType then
+            inputTypeChanged(newType)
+        end
+    end)
+
+    UserInputService.InputChanged:Connect(function(InputObject)
+        if InputObject.UserInputType == Enum.UserInputType.MouseMovement then
+            inputTypeChanged("keyboard")
+        end
+    end)
+end
+
+--= Return Module =--
+return ClientInputHandler

--- a/src/Infra/Client/Modules/ClientSessionPreservation.lua
+++ b/src/Infra/Client/Modules/ClientSessionPreservation.lua
@@ -1,0 +1,61 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+	All rights reserved.
+
+    ClientSessionPreservation.luau
+
+    Description:
+        
+]]
+
+--= Root =--
+local ClientSessionPreservation = { }
+
+--= Roblox Services =--
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local TeleportService = game:GetService("TeleportService")
+
+--= Dependencies =--
+
+local Signal = shared.GBMod("Signal") ---@module Signal
+local GetRemote = shared.GBMod("GetRemote")
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+local PRESERVED_KEYS = {
+    sessionId = true,
+    joinTime = true,
+    friendClockStart = true,
+    hasFriendsOnline = true,
+    totalFriendPlaytime = true
+}
+
+--= Variables =--
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+--= API Functions =--
+
+function ClientSessionPreservation:UpdateStoredData(key : string, value : any)
+    if PRESERVED_KEYS[key] == nil then
+        return
+    end
+
+    local sessionInfo = self:GetStoredData()
+    sessionInfo[key] = value
+
+    TeleportService:SetTeleportSetting("GAMEBEAST_SESSION", sessionInfo)
+end
+
+function ClientSessionPreservation:GetStoredData() : { [string]: any }
+    return TeleportService:GetTeleportSetting("GAMEBEAST_SESSION") or {}
+end
+
+--= Return Module =--
+return ClientSessionPreservation

--- a/src/Infra/Client/Public/Configs.lua
+++ b/src/Infra/Client/Public/Configs.lua
@@ -5,7 +5,7 @@
     Configs.lua
     
     Description:
-        No description provided.
+        Public API module for accessing client-specific configuration data.
     
 --]]
 

--- a/src/Infra/Client/Public/Configs.lua
+++ b/src/Infra/Client/Public/Configs.lua
@@ -17,7 +17,6 @@ local Configs = { }
 --= Dependencies =--
 
 local ClientConfigs = shared.GBMod("ClientConfigs") ---@module ClientConfigs
-local Signal = shared.GBMod("Signal") ---@module Signal
 
 --= Types =--
 
@@ -33,7 +32,7 @@ local Signal = shared.GBMod("Signal") ---@module Signal
 
 --= API Functions =--
 
-function Configs:Get(path : string | { string })
+function Configs:Get(path : string | { string }) : any
     return ClientConfigs:Get(path)
 end
 
@@ -55,12 +54,26 @@ function Configs:OnChanged(targetConfig : string | {string}, callback : (newValu
     return ClientConfigs:OnChanged(targetConfig, callback)
 end
 
-function Configs:OnReady(callback : (configs : any) -> ()) : RBXScriptSignal
+function Configs:OnReady(callback : (configs : any) -> ()) : RBXScriptConnection
     return ClientConfigs:OnReady(callback)
 end
 
 function Configs:IsReady() : boolean
     return ClientConfigs:IsReady()
+end
+
+-- Added for type consistency, but these methods are server-only.
+
+function Configs:GetForPlayer(player: Player, path: string | {string}) : any
+    error("Configs:GetForPlayer is a server-only method. Use :Get instead.")
+end
+
+function Configs:ObserveForPlayer(player: Player, targetConfig: string | {string}, callback: (newValue: any, oldValue: any) -> ()): RBXScriptConnection
+    error("Configs:ObserveForPlayer is a server-only method. Use :Observe instead.")
+end
+
+function Configs:OnChangedForPlayer(player: Player, targetConfig: string | {string}, callback : (newValue : any, oldValue : any) -> ()) : RBXScriptConnection
+    error("Configs:OnChangedForPlayer is a server-only method. Use :OnChanged instead.")
 end
 
 --= Return Module =--

--- a/src/Infra/MetaData.lua
+++ b/src/Infra/MetaData.lua
@@ -1,5 +1,5 @@
 -- Contains version information for the SDK
 
 return {
-    version = "v0.5.0"
+    version = "v0.6.0"
 }

--- a/src/Infra/Server/Modules/DatastoreBackup.lua
+++ b/src/Infra/Server/Modules/DatastoreBackup.lua
@@ -1,0 +1,80 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+    
+    DatastoreBackup.lua
+    
+    Description:
+        No description provided.
+    
+--]]
+
+--= Root =--
+local DatastoreBackup = { }
+
+--= Roblox Services =--
+local DataStoreService = game:GetService("DataStoreService")
+local RunService = game:GetService("RunService")
+
+--= Dependencies =--
+
+--= Types =--
+
+--= Constants =--
+local BACKUP_STORE_KEY = (RunService:IsStudio() and "Studio" or "") .. "_Gamebeast_Backup"
+
+--= Object References =--
+local BackupConfigStore = DataStoreService:GetDataStore(BACKUP_STORE_KEY)
+
+--= Variables =--
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+--= API Functions =--
+
+function DatastoreBackup:Set(key, value) : boolean
+    local success, errorMessage = pcall(function()
+        BackupConfigStore:SetAsync(key, value)
+    end)
+
+    if not success then
+        warn("Failed to save backup data for key '" .. key .. "': " .. tostring(errorMessage))
+    end
+
+    return success
+end
+
+function DatastoreBackup:Update(key, callback : (any) -> (any)) : boolean
+    local success, errorMessage = pcall(function()
+        BackupConfigStore:UpdateAsync(key, callback)
+    end)
+
+    if not success then
+        warn("Failed to update backup data for key '" .. key .. "': " .. tostring(errorMessage))
+    end
+
+    return success
+end
+
+function DatastoreBackup:Get(key) : (boolean, any)
+    local success, value = pcall(function()
+        return BackupConfigStore:GetAsync(key)
+    end)
+
+    if not success then
+        warn("Failed to retrieve backup data for key '" .. key .. "': " .. tostring(value))
+        return nil
+    end
+
+    return success, value
+end
+
+--= Initializers =--
+function DatastoreBackup:Init()
+    
+end
+
+--= Return Module =--
+return DatastoreBackup

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -52,6 +52,12 @@ local SYSTEM_MARKERS = {
 	--["GBClientPerformance"] = true,
 	--["GBServerPerformance"] = true,
 }
+local ALLOWED_VALUE_TYPES = {
+	["string"] = true,
+	["number"] = true,
+	["boolean"] = true,
+	["table"] = true, -- Only dictionaries, not arrays
+}
 
 --= Variables =--
 
@@ -103,7 +109,7 @@ end
 
 -- Core function, should be used internally by SDK rather than fireMarker
 -- function EngagementMarkers:CreateMarker(source, markerType, player, position, value)
-function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", markerType : string, value : number | {[string] : any}, metaData : {[string] : any})
+function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", markerType : string, value : any | {[string] : any}, metaData : {[string] : any})
 	metaData = metaData or {}
 	-- Validate all arguments.
 	local usageStr
@@ -132,11 +138,19 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		return
 	end
 	
-	local valueType = typeof(value)
-
-	if value ~= nil and valueType ~= "table" and valueType ~= "number" or (valueType == "table" and #value > 0) then
-		Utilities.GBWarn("Value for ".. source .." marker \"".. markerType.."\" should be a key-value dictionary, number, or nil.\n".. usageStr)
+	local valueType = type(value)
+	if valueType == "table" and #value > 0 then -- Array check
+		Utilities.GBWarn("Value argument for ".. source .." marker \"".. markerType.."\" should not be an array. Use a dictionary instead.")
 		return
+	end
+
+	if value ~= nil and ALLOWED_VALUE_TYPES[valueType] == nil then
+		Utilities.GBWarn("Value argument for ".. source .." marker \"".. markerType.."\" be a primitive type or dictionary, got: ".. valueType)
+  		return
+	end
+
+	if value ~= nil and valueType ~= "table" then
+		value = { value = value } -- Wrap non-table values in a table
 	end
 	
 	-- Interface allows for player instance or userId. We already validated args types, so just handle accordingly.

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -5,7 +5,7 @@
 	EngagementMarkers.luau
 	
 	Description:
-		No description provided.
+		Handles processing and sending engagement markers to the Gamebeast backend.
 	
 --]]
 
@@ -35,8 +35,6 @@ local Experiments = shared.GBMod("Experiments") ---@module Experiments
 
 --= Object References =--
 
-local FireMarkerEvent = GetRemote("Event", "FireMarker")
-
 --= Constants =--
 
 local CLIENT_DATA_TIMEOUT = RunService:IsStudio() and 10 or 45
@@ -44,7 +42,6 @@ local MAX_EVENT_QUEUE_SIZE = 1000
 local QUEUE_CHECK_TIME = 5
 local MAX_EVENT_REPORT_TIME = 10
 local SYSTEM_MARKERS = {
-	["Died"] = true,
 	["Logout"] = true,
 	["Login"] = true,
 	["Purchase"] = true,
@@ -76,6 +73,7 @@ local ClientInfoWarned = false
 local function GetSessionIdForPlayer(player) : string?
 	if SessionIds[player] == nil and player.Parent then
 		SessionIds[player] = HttpService:GenerateGUID(false)
+		ServerClientInfoHandler:UpdateClientData(player, "sessionId", SessionIds[player])
 	end
 
 	return SessionIds[player]
@@ -164,7 +162,7 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		["timestamp"] = metaData.timestampOverride or DateTime.now().UnixTimestampMillis,
 		["type"] = markerType,
 		["userId"] = player and player.UserId, 
-		["sessionId"] = player and GetSessionIdForPlayer(player),
+		["sessionId"] = nil, -- Resolved later
 		["value"] = value,
 		["properties"] = {
 			["sdkPlatform"] = "roblox",
@@ -211,6 +209,18 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 			entry.properties.device = ServerClientInfoHandler:GetClientInfo(player, "device")
 			entry.properties.deviceSubType = ServerClientInfoHandler:GetClientInfo(player, "deviceSubType")
 			entry.properties.inputType = ServerClientInfoHandler:GetClientInfo(player, "inputType")
+
+			-- Attempt to resolve session ID from client info so we preserve it across game sessions.
+			local sessionId = ServerClientInfoHandler:GetClientInfo(player, "sessionId")
+			if sessionId and sessionId ~= "" then
+				entry.sessionId = sessionId
+				if player.Parent then
+					SessionIds[player] = sessionId
+				end
+			else
+				entry.sessionId = GetSessionIdForPlayer(player)
+			end
+
 			addMarker()
 
 			-- Remove from waiting list if it exists

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -25,11 +25,13 @@ local Cleaner = shared.GBMod("Cleaner")
 local MetaData = shared.GBMod("MetaData")
 local GetRemote = shared.GBMod("GetRemote")
 local Utilities = shared.GBMod("Utilities")
+local HostServer = shared.GBMod("HostServer") ---@module HostServer
 local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
+local Experiments = shared.GBMod("Experiments") ---@module Experiments
+local FailedMarkers = shared.GBMod("FailedMarkers") ---@module FailedMarkers
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local LocalizationCache = shared.GBMod("LocalizationCache") ---@module LocalizationCache
 local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
-local Experiments = shared.GBMod("Experiments") ---@module Experiments
 
 --= Types =--
 
@@ -41,14 +43,6 @@ local CLIENT_DATA_TIMEOUT = RunService:IsStudio() and 10 or 45
 local MAX_EVENT_QUEUE_SIZE = 1000
 local QUEUE_CHECK_TIME = 5
 local MAX_EVENT_REPORT_TIME = 10
-local SYSTEM_MARKERS = {
-	["Logout"] = true,
-	["Login"] = true,
-	["Purchase"] = true,
-	["Chat"] = true,
-	--["GBClientPerformance"] = true,
-	--["GBServerPerformance"] = true,
-}
 local ALLOWED_VALUE_TYPES = {
 	["string"] = true,
 	["number"] = true,
@@ -89,20 +83,65 @@ local function EncodeVector3(vec)
 	return vectorArray
 end
 
+local function isMarkerDataValid(markerData : {}) : boolean
+	for _, value in markerData do
+		local valueType = type(value)
+		if ALLOWED_VALUE_TYPES[valueType] == nil then
+			return false
+		end
+
+		if valueType == "table" and not isMarkerDataValid(value) then
+			return false
+		end
+	end
+
+	return true
+end
+
+local function AddMarker(marker)
+	table.insert(MarkerQueue, marker)
+	
+	-- If marker queue size limit reached then send batch
+	if #MarkerQueue >= MAX_EVENT_QUEUE_SIZE then
+		EngagementMarkers:SendMarkers()
+	end
+end
+
 --= API Functions =--
 
 -- Send batch to GB
-function EngagementMarkers:SendMarkers()
-	if #MarkerQueue > 0 then
+function EngagementMarkers:SendMarkers(queue : {any}?) : (boolean, {[string] : any}?)
+	local isCustomQueue = queue ~= nil
+	queue = queue or MarkerQueue
+	if #queue > 0 then
 		LastEventReportTime = tick()
 		
 		local data = {
-			markers = MarkerQueue
+			markers = queue
 		}
 
-		MarkerQueue = {}
-		GBRequests:GBRequest("v1/markers", data)
+		if isCustomQueue then
+			MarkerQueue = {}
+		end
+		
+		local success, errorBody = GBRequests:GBRequestAsync("v1/markers", data)
+		if not success and isCustomQueue == false then
+			-- If request failed, add markers back to queue for retry
+			for _, marker in data.markers do
+				if not isMarkerDataValid(marker) then
+					Utilities.GBWarn("Invalid marker data detected, skipping marker")
+					continue
+				end
+
+				FailedMarkers:AddMarker(marker)
+			end
+
+			Utilities.GBWarn("Failed to send engagement markers to Gamebeast. Markers will be retried later.")
+		end
+		return success, errorBody
 	end
+
+	return true
 end
 
 -- Core function, should be used internally by SDK rather than fireMarker
@@ -181,15 +220,6 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		},
 	}
 
-	local function addMarker()
-		table.insert(MarkerQueue, entry)
-		
-		-- If marker queue size limit reached then send batch
-		if #MarkerQueue >= MAX_EVENT_QUEUE_SIZE then
-			EngagementMarkers:SendMarkers()
-		end
-	end
-
 	--[[
 		Ensure markers are sent with all required data.
 	]]
@@ -221,7 +251,7 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 				entry.sessionId = GetSessionIdForPlayer(player)
 			end
 
-			addMarker()
+			AddMarker(entry)
 
 			-- Remove from waiting list if it exists
 			if not shutdown then
@@ -310,16 +340,6 @@ end
 --= Initializers =--
 function EngagementMarkers:Init()
 	--NOTE: Firing markers from client is disabled. Shifting responsibility to the developer for security.
-	--[[ Handle client requests through API module
-	FireMarkerEvent.OnServerEvent:Connect(function(player, markerType, value, metaData)
-		if metaData then
-			metaData.player = player
-		else
-			metaData = {player = player}
-		end
-
-		EngagementMarkers:_createMarker("client", markerType, value, metaData)
-	end)]]
 
 	Players.ChildRemoved:Connect(function(player)
 		task.defer(function()
@@ -334,11 +354,66 @@ function EngagementMarkers:Init()
 			local lastReportElapsed = tick() - LastEventReportTime
 
 			if lastReportElapsed >= MAX_EVENT_REPORT_TIME then
-				EngagementMarkers:SendMarkers()
+				self:SendMarkers()
 			end
 			
 			if InternalConfigs:WaitForConfigsReady() then
 				MAX_EVENT_REPORT_TIME = InternalConfigs:GetActiveConfig("GBConfigs")["GBRates"]["EngagementMarkers"]
+			end
+		end
+	end)
+
+	task.spawn(function()
+		while task.wait(10) do
+			if not HostServer:IsHostServer() then
+				-- If not host, we don't need to send markers
+				continue
+			end
+
+			local processedCount = FailedMarkers:Get(1000, function(markers)
+				if #markers > 0 then
+					-- If we have markers to send, send them
+					local validMarkers = {}
+					local count = 0
+					for _, marker in markers do
+						if not isMarkerDataValid(marker) then
+							Utilities.GBWarn("Invalid marker data detected, skipping marker")
+							continue
+						end
+
+						table.insert(validMarkers, marker)
+						count += 1
+					end
+
+					local success, errorBody = self:SendMarkers(validMarkers)
+					if not success and errorBody and errorBody.rejectedMarkers then
+						if errorBody.ingestedMarkersCount then
+							return true -- Markers were sent, but were likely invalid for some reason.
+						end
+						
+						--[[ Logic to handle rejected markers if needed
+						local rejectedMarkerIds = {}
+						for _, rejectedMarkerInfo in errorBody.rejectedMarkers do
+							rejectedMarkerIds[rejectedMarkerInfo.marker.markerId] = true
+						end
+
+						for mIndex=1, count do
+							local markerId = validMarkers[mIndex].markerId
+							if rejectedMarkerIds[markerId] then
+								-- Do something with the rejected marker?
+							else
+								print("Successfully sent marker:", markerId)
+							end
+						end
+						]]
+					end
+
+					return success
+				end
+			end)
+
+			if processedCount <= 0 then
+				task.wait(55) -- Wait longer if no markers to process
 			end
 		end
 	end)
@@ -348,7 +423,9 @@ function EngagementMarkers:Init()
 			data.resolved(true)
 		end
 
-		EngagementMarkers:SendMarkers()
+		self:SendMarkers()
+
+		FailedMarkers:ForceSavePending()
 	end)
 end
 

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -120,7 +120,7 @@ function EngagementMarkers:SendMarkers(queue : {any}?) : (boolean, {[string] : a
 			markers = queue
 		}
 
-		if isCustomQueue then
+		if not isCustomQueue then
 			MarkerQueue = {}
 		end
 		

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -27,9 +27,9 @@ local GetRemote = shared.GBMod("GetRemote")
 local Utilities = shared.GBMod("Utilities")
 local HostServer = shared.GBMod("HostServer") ---@module HostServer
 local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
-local Experiments = shared.GBMod("Experiments") ---@module Experiments
 local FailedMarkers = shared.GBMod("FailedMarkers") ---@module FailedMarkers
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
+local Experiments = shared.GBMod("InternalExperiments") ---@module InternalExperiments
 local LocalizationCache = shared.GBMod("LocalizationCache") ---@module LocalizationCache
 local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
 

--- a/src/Infra/Server/Modules/EventsManager.luau
+++ b/src/Infra/Server/Modules/EventsManager.luau
@@ -55,7 +55,7 @@ end
 
 --= API Functions =--
 
-function EventsManager:OnStart(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptSignal
+function EventsManager:OnStart(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptConnection
 	return EventStartedSignal:Connect(function(name, info)
 		if name == eventName then
 			callback(info)
@@ -63,7 +63,7 @@ function EventsManager:OnStart(eventName : string, callback : (eventInfo : { [st
 	end)
 end
 
-function EventsManager:OnEnd(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptSignal
+function EventsManager:OnEnd(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptConnection
 	return EventEndedSignal:Connect(function(name, info)
 		if name == eventName then
 			callback(info)

--- a/src/Infra/Server/Modules/EventsManager.luau
+++ b/src/Infra/Server/Modules/EventsManager.luau
@@ -5,7 +5,7 @@
 	EventsManager.luau
 	
 	Description:
-		No description provided.
+		Handles the management of defined events, including starting and ending events based on time.
 	
 --]]
 

--- a/src/Infra/Server/Modules/Experiments.luau
+++ b/src/Infra/Server/Modules/Experiments.luau
@@ -261,7 +261,7 @@ end
 
 	Returns a function to cancel listening.
 ]]
-function Experiments:ListenForPlayerAssignment(player: Player, callback: (groupId: number?) -> ()): RBXScriptSignal
+function Experiments:ListenForPlayerAssignment(player: Player, callback: (groupId: number?) -> ()): RBXScriptConnection
 	local listenerCleaner = Cleaner.new()
 	local connection = SignalConnection.new(function()
 		listenerCleaner:Destroy()

--- a/src/Infra/Server/Modules/FailedMarkers.lua
+++ b/src/Infra/Server/Modules/FailedMarkers.lua
@@ -1,0 +1,224 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+    
+    FailedMarkers.lua
+    
+    Description:
+        - Ordered datastore holds keys for batches of failed markers.
+        - Normal datastore holds the markers themselves.
+        - 2 requests per batch. One to delete the ordered key, and one to delete the markers.
+        Enum.DataStoreRequestType.SetIncrementSortedAsync
+        Enum.DataStoreRequestType.SetIncrementAsync
+--]]
+
+--= Root =--
+local FailedMarkers = { }
+
+--= Roblox Services =--
+local HttpService = game:GetService("HttpService")
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local DataStoreService = game:GetService("DataStoreService")
+
+--= Dependencies =--
+
+local Utilities = shared.GBMod("Utilities") ---@module Utilities
+
+--= Types =--
+
+--= Object References =--
+
+local MarkersDataStore = DataStoreService:GetDataStore("GB_FailedMarkers")
+local OrderedMarkersDataStore = DataStoreService:GetOrderedDataStore("GB_FailedMarkers")
+
+--= Constants =--
+
+local MAX_RETRY_COUNT = 3 -- Maximum number of retries for saving markers
+local MAX_QUEUE_SIZE = 400
+local MAX_MARKERS_PER_BATCH = 1000 -- Maximum markers per batch
+
+--= Variables =--
+
+local RetryQueue = {} :: {{retryCount : number, markers : {any}}}
+local MarkersPendingBatch = {} :: {any}
+local MarkersPendingCount = 0
+
+
+--= Public Variables =--
+
+--= Internal Functions =--
+
+--= API Functions =--
+
+function FailedMarkers:CanAfford() : boolean
+    local budget = DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.SetIncrementAsync)
+    local sortedBudget = DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.SetIncrementSortedAsync)
+    local getSortedBudget = DataStoreService:GetRequestBudgetForRequestType(Enum.DataStoreRequestType.GetSortedAsync)
+
+    -- Check if we have enough budget for both requests
+    return getSortedBudget > 1 and budget >= 20 and sortedBudget >= 12
+end
+
+-- Uses Budget of 1 Ordered and 1 Normal
+function FailedMarkers:Save(markers : {any}, isRetry : boolean?) : boolean
+    local key = HttpService:GenerateGUID(false)
+    local markerCount = #markers
+    if markerCount > MAX_MARKERS_PER_BATCH then
+        Utilities.GBWarn("Too many markers to save in one batch:", markerCount)
+        return false
+    end
+
+    local success, errorMessage = pcall(function()
+        if not self:CanAfford() then
+            error("Not enough budget to save markers")
+        end
+        -- Add the key to the ordered datastore
+        OrderedMarkersDataStore:SetAsync(key, markerCount)
+        
+        -- Save the markers to the normal datastore
+        MarkersDataStore:SetAsync(key, markers)
+    end)
+
+    if not success then
+        --Utilities.GBWarn("Failed to save markers:", errorMessage)
+        if not isRetry then
+            if #RetryQueue + 1 >= MAX_QUEUE_SIZE then
+                -- If the queue is full, remove the oldest item
+                table.remove(RetryQueue, 2)
+            end
+
+            table.insert(RetryQueue, {
+                retryCount = 0,
+                markers = markers
+            })
+        end
+        return false
+    end
+
+    return true
+end
+
+-- Uses max budget of 1 GetSorted, 20 SetIncrementAsync, and 10 SetIncrementSortedAsync
+function FailedMarkers:Get(maxMarkers : number, callback : (({any}) -> boolean)?) : number
+    if not self:CanAfford() then
+        return {}
+    end
+
+    local keyPageSuccess, keyPages = pcall(function()
+        return OrderedMarkersDataStore:GetSortedAsync(false, 10) -- Get the first 10 keys
+    end)
+
+    if not keyPageSuccess then
+        Utilities.GBWarn("Failed to retrieve keys from OrderedMarkersDataStore:", keyPages)
+        return {}
+    end
+
+    local markers = {}
+    local count = 0
+    local toDelete = {}
+
+    for _, kvPair in pairs(keyPages:GetCurrentPage()) do
+        if kvPair.value + count > maxMarkers then
+            -- If adding this batch exceeds the maxMarkers limit, break
+            break
+        end
+
+
+        local success, data = pcall(function()
+            return MarkersDataStore:GetAsync(kvPair.key)
+        end)
+
+        if data == nil then
+            -- If the data is nil, it means the key was deleted or doesn't exist
+            continue
+        end
+
+    
+        table.insert(toDelete, kvPair.key)
+
+        if success and data then
+            for _, marker in pairs(data) do
+                table.insert(markers, marker)
+            end
+
+            count += kvPair.value
+        else
+            Utilities.GBWarn("Failed to retrieve markers for key:", kvPair.key, "Error:", data)
+        end
+    end
+
+
+    local success = callback(markers)
+    if success then
+        for _, key in toDelete do
+            local deleteSuccess, deleteError = pcall(function()
+                OrderedMarkersDataStore:RemoveAsync(key)
+                MarkersDataStore:RemoveAsync(key)
+            end)
+
+            if not deleteSuccess then
+                Utilities.GBWarn("Failed to delete key from OrderedMarkersDataStore:", key, "Error:", deleteError)
+            end
+        end
+    end
+
+
+    return count
+end
+
+function FailedMarkers:ForceSavePending()
+    if MarkersPendingCount > 0 then
+        -- If there are pending markers, save them immediately
+        local toSave = MarkersPendingBatch
+        MarkersPendingBatch = {}
+        MarkersPendingCount = 0
+
+        self:Save(toSave)
+    end
+end
+
+function FailedMarkers:AddMarker(marker : {[string] : any})
+    MarkersPendingCount += 1
+    MarkersPendingBatch[MarkersPendingCount] = marker
+    if MarkersPendingCount >= MAX_MARKERS_PER_BATCH then
+        -- If we have enough markers, save them
+        local toSave = MarkersPendingBatch
+        MarkersPendingBatch = {}
+        MarkersPendingCount = 0
+
+        self:Save(toSave)
+    end
+end
+
+--= Initializers =--
+function FailedMarkers:Init()
+    task.spawn(function()
+        while true do
+            if #RetryQueue > 0 then
+                if self:CanAfford() then
+                    -- If budget is low, wait before retrying
+                    task.wait(5)
+                    continue
+                end
+
+
+                local retryItem = table.remove(RetryQueue, 1)
+                -- Attempt to save the markers again
+                if retryItem.retryCount < MAX_RETRY_COUNT then
+                    retryItem.retryCount += 1
+                    local success = self:Save(retryItem.markers, true)
+                    if not success then
+                        table.insert(RetryQueue, retryItem) -- Reinsert the item for retry
+                        task.wait(5)
+                    end
+                else
+                    Utilities.GBWarn("Failed to save markers after maximum retries")
+                end
+            end
+            task.wait(2)
+        end
+    end)
+end
+
+--= Return Module =--
+return FailedMarkers

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -31,7 +31,7 @@ local MetaData = shared.GBMod("MetaData") ---@module MetaData
 local URL_SUFFIX = "/sdk"
 local ENDPOINTS = {
 	{ 
-		URL = "https://api.gamebeast.gg" .. URL_SUFFIX, -- http://localhost:3001 -- https://api.gamebeast.gg -- https://api.stage.gamebeast.gg
+		URL = "https://api.gamebeast.gg", -- http://localhost:3001 -- https://api.gamebeast.gg -- https://api.stage.gamebeast.gg
 		Requests = { -- NOTE: If you require URL parameters, use {param} in the route string. Example: "v1/servers/roblox/{serverId}"
 			["v1/markers"] = "POST",
 			["v1/requests"] = "GET",
@@ -70,7 +70,7 @@ local function GetEndpointForRequest(requestRoute : string) : (string?, string?)
 			end
 		end
 
-		return endpoint.URL, current["__method"]
+		return ((DataCache:Get("Settings").customUrl or endpoint.URL)..URL_SUFFIX), current["__method"]
 	end
 end
 

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -135,14 +135,8 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 		["isstudio"] = tostring(isStudio),
 		["sdkversion"] = MetaData.version,
 		["universeid"] = tostring(game.GameId),
+		["serverid"] = Utilities.getServerId(),
 	}
-
-	-- JobId is undefined in studio so send a hard coded default for this environment
-	if isStudio then
-		headers["serverid"] = "00000000-0000-0000-0000-000000000000"
-	else
-		headers["serverid"] = game.JobId
-	end
 
 	local url = GBDomain.. "/".. requestRoute
 

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -38,8 +38,6 @@ local ENDPOINTS = {
 			["v1/requests/completed"] = "POST",
 			["v1/requests/started"] = "PUT",
 			["v1/configurations"] = "GET",
-			["v1/heatmap"] = "POST",
-			["v1/heatmap/waypoint"] = "POST",
 			["v1/latest/version?platform=roblox"] = "GET",
 			["v1/experiments/assignments"] = "POST",
 			["v1/servers/roblox/{serverId}"] = "POST"
@@ -116,8 +114,15 @@ end
 
 --YEILDS 
 function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any}, maxRetries : number?) : (boolean, any?)
-	RequestProcessingCount += 1
 	local GBDomain, requestMethod = GetEndpointForRequest(requestRoute)
+	
+	if not GBDomain or not requestMethod then
+		Utilities.GBWarn("Invalid request route:", requestRoute)
+		return false, nil
+	end
+
+	RequestProcessingCount += 1
+
 	local requestBody
 	args = args or {}
 

--- a/src/Infra/Server/Modules/HostServer.luau
+++ b/src/Infra/Server/Modules/HostServer.luau
@@ -5,7 +5,8 @@
 	HostServer.luau
 	
 	Description:
-		No description provided.
+		Handles the host server role in a Gamebeast server environment.
+		Ensures that only one host server exists at a time and manages cross-server communication.
 	
 --]]
 

--- a/src/Infra/Server/Modules/HostServer.luau
+++ b/src/Infra/Server/Modules/HostServer.luau
@@ -42,6 +42,7 @@ local OtherHostFound = false
 local LastHeartbeatTick = tick()
 local ServersSinceStartup = 0
 local LastHeartbeatSent = os.time()
+local ServerId = Utilities.getServerId()
 
 --= Public Variables =--
 
@@ -55,7 +56,7 @@ end
 
 local function SendHeartbeat()
 	LastHeartbeatSent = os.time()
-	Utilities.publishMessage(HOST_HEARTBEAT_TOPIC, {Source = game.JobId})
+	Utilities.publishMessage(HOST_HEARTBEAT_TOPIC, {Source = ServerId})
 end
 
 --= API Functions =--
@@ -96,12 +97,12 @@ function HostServer:Init()
 	-- If ping is received on this channel and it is not from ourself, then another host server exists and we relinquish role
 	local success, reason = pcall(function()
 		MessagingService:SubscribeAsync(HOST_HEARTBEAT_TOPIC, function(message : {Sent : number, Data : {Source : string}})
-			if message.Data.Source == game.JobId then return end
+			if message.Data.Source == ServerId then return end
 
 			LastHeartbeatTick = tick()
 			--print("New host server found: ".. message.Data)
 			OtherHostFound = true
-			if message.Data.Source > game.JobId then -- If other server should be host
+			if message.Data.Source > ServerId then -- If other server should be host
 				self:RelinquishHostServerRole()
 			end
 		end)

--- a/src/Infra/Server/Modules/HostServer.luau
+++ b/src/Infra/Server/Modules/HostServer.luau
@@ -31,8 +31,9 @@ local Utilities = shared.GBMod("Utilities") ---@module Utilities
 -- Messaging service topics for cross server communication
 local HOST_HEARTBEAT_TOPIC = "GB_HOST_HEARTBEAT"
 local SERVER_SHUTDOWN_TOPIC = "GB_SERVER_SHUTDOWN"
+local SERVER_STARTUP_TOPIC = "GB_SERVER_STARTUP"
 -- How often we check if no host exists and resolve
-local HEARTBEAT_INTERVAL = 30
+local HEARTBEAT_INTERVAL = 10
 
 --= Variables =--
 
@@ -52,9 +53,9 @@ local function assumeHostServerRole()
 	HostServerStatus = true
 end
 
-local function SendHeartbeat(newFlag : boolean?)
+local function SendHeartbeat()
 	LastHeartbeatSent = os.time()
-	Utilities.publishMessage(HOST_HEARTBEAT_TOPIC, {Source = game.JobId, NewServer = newFlag})
+	Utilities.publishMessage(HOST_HEARTBEAT_TOPIC, {Source = game.JobId})
 end
 
 --= API Functions =--
@@ -69,17 +70,16 @@ function HostServer:RelinquishHostServerRole()
 	HostServerStatus = false
 end
 
--- Sends out signal to see if the host server responds. If no response, attempts to assume host server role
-function HostServer:CheckHostServerActive(isNew : boolean?)
+-- If no response, attempts to assume host server role
+function HostServer:CheckHostServerActive()
 	if HostServerStatus then
 		return
 	end
 
 	OtherHostFound = false
 
-	SendHeartbeat(isNew)
-	task.wait(2)
-	
+	task.wait(HEARTBEAT_INTERVAL + 2) -- Wait a bit to see if we get a response from an active host server
+
 	if not OtherHostFound then
 		assumeHostServerRole()
 	end
@@ -95,28 +95,24 @@ function HostServer:Init()
 
 	-- If ping is received on this channel and it is not from ourself, then another host server exists and we relinquish role
 	local success, reason = pcall(function()
-		MessagingService:SubscribeAsync(HOST_HEARTBEAT_TOPIC, function(message : {Sent : number, Data : {Source : string, NewServer : boolean?}})
+		MessagingService:SubscribeAsync(HOST_HEARTBEAT_TOPIC, function(message : {Sent : number, Data : {Source : string}})
 			if message.Data.Source == game.JobId then return end
 
 			LastHeartbeatTick = tick()
 			--print("New host server found: ".. message.Data)
-
+			OtherHostFound = true
 			if message.Data.Source > game.JobId then -- If other server should be host
 				self:RelinquishHostServerRole()
-				OtherHostFound = true
-			elseif HostServerStatus then -- If we are host
-				--Check timestamp, dont reply to any that are older than last heartbeat
-				if message.Sent > LastHeartbeatSent then
-					SendHeartbeat()
-				end
-			end
-
-			if message.Data.NewServer then
-				ServersSinceStartup += 1
 			end
 		end)
 	end)
 	
+	Utilities.promiseReturn(1, function()
+		MessagingService:SubscribeAsync(SERVER_STARTUP_TOPIC, function()
+			ServersSinceStartup += 1
+		end)
+	end)
+
 	Utilities.promiseReturn(1, function()
 		MessagingService:SubscribeAsync(SERVER_SHUTDOWN_TOPIC, function(message)
 			if message.Data < ServersSinceStartup then
@@ -131,11 +127,9 @@ function HostServer:Init()
 				SendHeartbeat()
 			elseif tick() - LastHeartbeatTick > ((HEARTBEAT_INTERVAL + 5) + ServersSinceStartup) then -- Non-host
 				LastHeartbeatTick = tick()
-				self:CheckHostServerActive()
+				assumeHostServerRole()
 			end
 		end)
-
-		self:CheckHostServerActive(true)
 
 		game:BindToClose(function(reason)
 			if reason == Enum.CloseReason.DeveloperShutdown or reason == Enum.CloseReason.DeveloperUpdate then
@@ -144,8 +138,11 @@ function HostServer:Init()
 
 			Utilities.publishMessage(SERVER_SHUTDOWN_TOPIC, ServersSinceStartup)
 		end)
+
+		Utilities.publishMessage(SERVER_STARTUP_TOPIC, true)
+		self:CheckHostServerActive()
 	else
-		Utilities.GBWarn("Failed to subscribe to host heartbeat topic, starting rogue host server...", reason)
+		Utilities.GBWarn("Failed to subscribe to host heartbeat topic, starting rogue host server with reason: ".. reason)
 		assumeHostServerRole()
 	end
 end

--- a/src/Infra/Server/Modules/InternalConfigs.luau
+++ b/src/Infra/Server/Modules/InternalConfigs.luau
@@ -5,7 +5,7 @@
 	InternalConfigs.luau
 	
 	Description:
-		No description provided.
+		Internal module for managing configuration data across the server and clients.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalExperiments.luau
+++ b/src/Infra/Server/Modules/InternalExperiments.luau
@@ -10,6 +10,7 @@ local Signal = shared.GBMod("Signal")
 local Utilities = shared.GBMod("Utilities")
 local SignalConnection = shared.GBMod("SignalConnection") ---@module SignalConnection
 local Cleaner = shared.GBMod("Cleaner") ---@module Cleaner
+local Types = require(script.Parent.Parent.Parent.Types)
 
 -- Types
 type ConfigSnapshot = {
@@ -22,6 +23,8 @@ type ConfigSnapshot = {
 }
 type AvailableExperimentGroupSnapshot = {
 	id: number,
+	groupName: string,
+	experimentName: string,
 	endsAt: number?,
 	configs: ConfigSnapshot,
 }
@@ -313,6 +316,26 @@ function Experiments:ListenForPlayerAssignment(player: Player, callback: (groupI
 	end))
 
 	return connection
+end
+
+--[[
+	Returns metadata about the specified experiment group, if it has been
+	fetched from the backend, and is active.
+]]
+function Experiments:GetActiveGroupMetadata(groupId: number): Types.ExperimentGroupMetadata?
+	if not currentAssignmentState then
+		return nil
+	end
+
+	local groupState = currentAssignmentState.activeGroupStateById[groupId]
+	if not groupState then
+		return nil
+	end
+
+	return {
+		experimentName = groupState.group.experimentName,
+		groupName = groupState.group.groupName,
+	}
 end
 
 --[[

--- a/src/Infra/Server/Modules/InternalExperiments.luau
+++ b/src/Infra/Server/Modules/InternalExperiments.luau
@@ -237,9 +237,7 @@ end
 	specific players and servers.
 ]]
 function Experiments:ProcessExperimentReassignmentRequest(request: ExperimentReassignmentPropagationRequest)
-	local currentGameserverId = if game.JobId == ""
-		then "00000000-0000-0000-0000-000000000000"
-		else game.JobId
+	local currentGameserverId = Utilities.getServerId()
 
 	-- If this gameserver is included in the request, queue reassignment
 	if table.find(request.gameserverIds, currentGameserverId) then

--- a/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
@@ -5,7 +5,7 @@
 	PurchaseAnalytics.luau
 	
 	Description:
-		No description provided.
+		Handles tracking purchases made by players in the server.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
@@ -74,7 +74,7 @@ local function FlushProductPurchaseCache(player : Player)
 
 	for _, data in ipairs(playerCache) do
 		task.spawn(function()
-			PurchaseAnalytics:UpdatePlayerSpend(player, data.itemId, Enum.InfoType.Product, {position = data.position, timestampOverride = data.timestamp})
+			PurchaseAnalytics:UpdatePlayerSpend(player, false, data.itemId, Enum.InfoType.Product, {position = data.position, timestampOverride = data.timestamp})
 		end)
 	end
 
@@ -83,7 +83,7 @@ end
 
 --= API Functions =--
 
-function PurchaseAnalytics:UpdatePlayerSpend(player : Player | number, itemId : number, itemType : Enum.InfoType, metadataOverride : {[string] : any}?)
+function PurchaseAnalytics:UpdatePlayerSpend(player : Player | number, fromReceipt : boolean, itemId : number, itemType : Enum.InfoType, metadataOverride : {[string] : any}?)
 	local player = Utilities.resolvePlayerObject(player)
 
 	local itemInfo = GetProductInfo(itemId, itemType)
@@ -109,6 +109,7 @@ function PurchaseAnalytics:UpdatePlayerSpend(player : Player | number, itemId : 
 
 	-- Don't send redundant information over the wire
 	local args = {
+		["fromReceipt"] = fromReceipt,
 		["type"] = ENUM_TO_TYPE[itemType] or "unknown",
 		["id"] = itemId,
 		["price"] = clientPrice or itemInfo.PriceInRobux,
@@ -151,7 +152,7 @@ function PurchaseAnalytics:DevProductPurchased(fromReceipt : boolean, playerId :
 	if fromReceipt then
 		UsingProductReceipts = true
 		DevProductEventCache[player] = nil
-		self:UpdatePlayerSpend(playerId, itemId, Enum.InfoType.Product, {position = position})
+		self:UpdatePlayerSpend(playerId, true, itemId, Enum.InfoType.Product, {position = position})
 	else
 		DevProductEventCache[player] = DevProductEventCache[player] or {}
 		local playerCache = DevProductEventCache[player]
@@ -173,14 +174,14 @@ function PurchaseAnalytics:Init()
 	-- Purchase records handler for gamepasses
 	MarketplaceService.PromptGamePassPurchaseFinished:Connect(function(player, gamePassId, wasPurchased)
 		if wasPurchased then
-			self:UpdatePlayerSpend(player, gamePassId, Enum.InfoType.GamePass)
+			self:UpdatePlayerSpend(player, false, gamePassId, Enum.InfoType.GamePass)
 		end
 	end)
 
 	-- Purchase records handler for assets / other
 	MarketplaceService.PromptPurchaseFinished:Connect(function(player, assetId, wasPurchased)
 		if wasPurchased then
-			self:UpdatePlayerSpend(player, assetId, Enum.InfoType.Asset)
+			self:UpdatePlayerSpend(player, false, assetId, Enum.InfoType.Asset)
 		end
 	end)
 
@@ -192,7 +193,7 @@ function PurchaseAnalytics:Init()
 			end)
 
 			if success and subscriptionStatus.IsSubscribed then
-				self:UpdatePlayerSpend(player, subscriptionId, Enum.InfoType.Subscription)
+				self:UpdatePlayerSpend(player, false, subscriptionId, Enum.InfoType.Subscription)
 			end
 		end
 	end)

--- a/src/Infra/Server/Modules/InternalMarkers/SentimentCapture.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SentimentCapture.luau
@@ -5,7 +5,8 @@
 	SentimentCapture.luau
 	
 	Description:
-		No description provided.
+		Captures player chat messages and sends them as markers for sentiment analysis.
+		Messages are filtered for compliance before being sent.
 	
 --]]
 

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -92,11 +92,17 @@ function SessionMarkers:Init()
 		local teleportingToPlace = PlayerStats:GetStat(player, "teleporting_to")
 		if ServerClientInfoHandler:IsClientInfoResolved(player) == true and teleportingToPlace and PlacesInUniverse[teleportingToPlace] then
 			-- If the player was teleporting, we don't send a Logout marker
-			return
+			EngagementMarkers:SDKMarker("PlaceTeleport", {
+					sourcePlaceId = game.PlaceId,
+					destinationPlaceId = teleportingToPlace,
+					sessionLength = Utilities.roundNum(os.time() - PlayerStats:GetStat(player, "join_time"), 0.1)
+				}, 
+				{player = player, position = position}
+			)
+		else
+			-- Send Logout marker with relevant info
+			EngagementMarkers:SDKMarker("Logout", args, {player = player, position = position})
 		end
-
-		-- Send Logout marker with relevant info
-		EngagementMarkers:SDKMarker("Logout", args, {player = player, position = position})
 	end)
 
 	task.spawn(function()

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -5,7 +5,8 @@
 	SessionMarkers.luau
 	
 	Description:
-		No description provided.
+		Handles session markers for player login and logout events.
+		Tracks player session length and friend playtime percentage.
 	
 --]]
 
@@ -17,6 +18,7 @@ local SessionMarkers = { }
 
 local Players = game:GetService("Players")
 local PolicyService = game:GetService("PolicyService")
+local AssetService = game:GetService("AssetService")
 
 --= Dependencies =--
 
@@ -24,6 +26,7 @@ local Utilities = shared.GBMod("Utilities")
 local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module Markers
 local PlayerStats = shared.GBMod("PlayerStats") ---@module PlayerStats
 local SocialHandler = shared.GBMod("SocialHandler") ---@module SocialHandler
+local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
 
 --= Types =--
 
@@ -34,7 +37,7 @@ local SocialHandler = shared.GBMod("SocialHandler") ---@module SocialHandler
 --= Variables =--
 
 local LastCharPositions = {}
-
+local PlacesInUniverse = {}
 
 --= Public Variables =--
 
@@ -51,34 +54,76 @@ function SessionMarkers:Init()
 			LastCharPositions[player] = position
 		end)
 		
-		-- Send Login marker with relevant session information
-		local policyInfo = Utilities.promiseReturn(1, function()
-			return PolicyService:GetPolicyInfoForPlayerAsync(player)
-		end)
+		local joinData = player:GetJoinData()
+		-- Check if the player teleported into the game. Only send login marker if they did not teleport in.
+        if joinData.SourceGameId ~= game.GameId then
+            
+            -- Send Login marker with relevant session information
+			local policyInfo = Utilities.promiseReturn(1, function()
+				return PolicyService:GetPolicyInfoForPlayerAsync(player)
+			end)
 
-		local loginArgs = {
-			policyInfo = policyInfo
-		}
+			local loginArgs = {
+				policyInfo = policyInfo
+			}
 
-		EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil})
+			EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil})
+
+			PlayerStats:OnDefaultStatsResolved(function()
+				ServerClientInfoHandler:UpdateClientData(player, "joinTime", PlayerStats:GetStat(player, "join_time"))
+			end)
+        end
 	end)
 
-	Players.PlayerRemoving:Connect(function(player)		
+	Players.PlayerRemoving:Connect(function(player)
 		-- Collect last position for Logout marker
 		local position = LastCharPositions[player]
 		LastCharPositions[player] = nil
 		
 		-- Compute session length in addition to backend for reasons(?)
-		local sessionLength = Utilities.roundNum(tick() - PlayerStats:GetStat(player, "session_length"), 0.1)
+		local clientJoinTime = ServerClientInfoHandler:GetClientInfo(player, "joinTime")
+		local sessionLength = Utilities.roundNum(os.time() - (clientJoinTime or PlayerStats:GetStat(player, "join_time")), 0.1)
 		local friendPlaytimePercent = SocialHandler:GetTotalFriendPlaytime(player)
 		local args = {
 			["sessionLength"] = sessionLength,
 			["sessionLengthPercentageWithFriends"] = if friendPlaytimePercent then Utilities.roundNum(friendPlaytimePercent/sessionLength, 0.01) else nil
 		}
 
+		local teleportingToPlace = PlayerStats:GetStat(player, "teleporting_to")
+		if ServerClientInfoHandler:IsClientInfoResolved(player) == true and teleportingToPlace and PlacesInUniverse[teleportingToPlace] then
+			-- If the player was teleporting, we don't send a Logout marker
+			return
+		end
+
 		-- Send Logout marker with relevant info
 		EngagementMarkers:SDKMarker("Logout", args, {player = player, position = position})
 	end)
+
+	task.spawn(function()
+		-- Collect all places in the universe for sessionId preservation
+		local success, err = pcall(function()
+			local placesPages = AssetService:GetGamePlacesAsync()
+			while true do
+				-- Wait for the places to be loaded
+				for _, place in pairs(placesPages:GetCurrentPage()) do
+					if not PlacesInUniverse[place.PlaceId] then
+						PlacesInUniverse[place.PlaceId] = place
+					end
+				end
+
+				if placesPages.IsFinished then
+					break
+				else
+					placesPages:AdvanceToNextPageAsync()
+				end
+			end
+		end)
+
+		if not success then
+			Utilities.GBWarn("Failed to get places in universe:", err)
+		end
+	end)
+	
 end
 
 --= Return Module =--

--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -22,6 +22,7 @@ local Players = game:GetService("Players")
 local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module EngagementMarkers
 local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
 local PlayerStats = shared.GBMod("PlayerStats") ---@module PlayerStats
+local Cleaner = shared.GBMod("Cleaner") ---@module Cleaner
 
 --= Types =--
 
@@ -39,11 +40,8 @@ local FriendsInServerCache = {}
 
 local function CreateCacheEntry(player : Player) : { [string]: any }
     local newEntry = {
-        Timestamp = tick(),
-        TotalTime = 0,
-        FriendInServer = false,
-        UpdatedByClient = false,
-        _connection = nil
+        LastClientUpdate = 0,
+        Cleaner = Cleaner.new(),
     }
 
     FriendsInServerCache[player] = newEntry
@@ -55,16 +53,19 @@ end
 
 function SocialHandler:GetTotalFriendPlaytime(player : Player) : number?
     local cachedData = FriendsInServerCache[player]
-    if not cachedData or cachedData.UpdatedByClient == false then
+    if cachedData == nil or ServerClientInfoHandler:IsClientInfoResolved(player) == false then
         return nil
     end
-
+    
     FriendsInServerCache[player] = nil
+    
+    local hasFriendsOnline = ServerClientInfoHandler:GetClientInfo(player, "hasFriendsOnline")
+    local totalTime = ServerClientInfoHandler:GetClientInfo(player, "totalFriendPlaytime")
 
-    if cachedData.FriendInServer then
-        return cachedData.TotalTime + (tick() - cachedData.Timestamp)
+    if hasFriendsOnline then
+        return totalTime + (os.clock() - cachedData.LastClientUpdate)
     else
-        return cachedData.TotalTime
+        return totalTime
     end
 end
 
@@ -81,49 +82,24 @@ function SocialHandler:Init()
             }, { player = player })
         end
 
-        cacheEntry._connection = ServerClientInfoHandler:OnClientInfoChanged(player, function(key, value)
-            if key == "friendsOnline" then
-                local hasFriendsInServer = value > 0
+        cacheEntry.Cleaner:Add(ServerClientInfoHandler:OnClientInfoChanged(player, function(key, _)
+            if key == "friendClockStart" then
+                cacheEntry.LastClientUpdate = os.clock()
+            end
+        end))
 
-                if cacheEntry.UpdatedByClient == false and hasFriendsInServer then
-                    local joinedAt = PlayerStats:GetStat(player, "session_length")
-                    cacheEntry.TotalTime += (tick() - joinedAt)
+        local activeTeleportCount = 0
+        player.OnTeleport:Connect(function(teleportState, placeId)
+            if teleportState == Enum.TeleportState.RequestedFromServer then
+                PlayerStats:SetStat(player, "teleporting_to", placeId)
+                activeTeleportCount += 1
+            elseif teleportState == Enum.TeleportState.Failed then
+                activeTeleportCount -= 1
+                if activeTeleportCount <= 0 then
+                    PlayerStats:SetStat(player, "teleporting_to", nil)
                 end
-
-                cacheEntry.UpdatedByClient = true
-
-                if hasFriendsInServer == false and cacheEntry.FriendInServer == true then
-                    cacheEntry.TotalTime += (tick() - cacheEntry.Timestamp)
-                elseif hasFriendsInServer == true and cacheEntry.FriendInServer == false then
-                    cacheEntry.Timestamp = tick()
-                end
-
-                cacheEntry.FriendInServer = hasFriendsInServer
             end
         end)
-
-        --NOTE: Disabled since large servers with lots of players joining will result in too many HTTP requests.
-        --[[ Look for friends
-        for _, potentialFriend in ipairs(Players:GetPlayers()) do
-            if potentialFriend ~= player and (player:IsFriendsWith(potentialFriend.UserId) or player.UserId < 0) then
-                FriendStatusUpdated(player, potentialFriend, true)
-                FriendStatusUpdated(potentialFriend, player, true)
-            end
-
-            if player.Parent == nil then
-                return
-            end
-        end
-
-        local cachedData = FriendsInServerCache[player]
-        if cachedData and #cachedData.Friends > 0 then
-            
-            --NOTE: This prevents sending a marker for every friend in the server. ie: you join a game with 100 friends, we'd send 100 markers.
-            EngagementMarkers:SDKMarker("JoinedFriend", {
-                friendUserId = cachedData.Friends[1].UserId,
-                friendsInServer = #cachedData.Friends,
-            }, { player = player })
-        end]]
     end
 
     Players.PlayerAdded:Connect(playerAdded)
@@ -133,10 +109,9 @@ function SocialHandler:Init()
 	
     Players.PlayerRemoving:Connect(function(player)
         if FriendsInServerCache[player] then
-            FriendsInServerCache[player]._connection:Disconnect()
+            FriendsInServerCache[player].Cleaner:Destroy()
         end
     end)
-
 end
 
 --= Return Module =--

--- a/src/Infra/Server/Modules/LocalizationCache.lua
+++ b/src/Infra/Server/Modules/LocalizationCache.lua
@@ -5,7 +5,7 @@
     LocalizationCache.lua
     
     Description:
-        No description provided.
+        Caches localization data for players, such as region and locale IDs.
     
 --]]
 

--- a/src/Infra/Server/Modules/PlayerStats.luau
+++ b/src/Infra/Server/Modules/PlayerStats.luau
@@ -5,7 +5,7 @@
     PlayerStats.luau
     
     Description:
-        No description provided.
+        Holds general player state data.
     
 --]]
 
@@ -18,17 +18,25 @@ local Players = game:GetService("Players")
 
 --= Dependencies =--
 
+local Signal = shared.GBMod("Signal") ---@module Signal
+local Schema = shared.GBMod("Schema") ---@module Schema
+
 --= Types =--
 
 --= Object References =--
 
+local DefaultStatsResolved = Signal.new()
+
 --= Constants =--
 
-local DEFAULT_SCHEMA = {
-    session_length = function()
-		return tick()
-	end
-}
+local DEFAULT_SCHEMA = Schema.new({
+    join_time = { default = function()
+        return os.time()
+    end, type = "number" },
+    teleporting_to = { default = function()
+        return nil 
+    end, type = {"number", "nil"} }
+})
 
 --= Variables =--
 
@@ -39,6 +47,18 @@ local SessionData = {}
 --= Internal Functions =--
 
 --= API Functions =--
+
+function PlayerStats:SetStat(player : Player, stat : string, value : any)
+    if not SessionData[player] and player.Parent then
+        self:Reset(player)
+    end
+
+    if not DEFAULT_SCHEMA:HasKey(stat) then
+        error("Cannot set stat: " .. stat)
+    end
+
+    SessionData[player][stat] = value
+end
 
 function PlayerStats:GetStats(player : Player)
     return SessionData[player]
@@ -56,10 +76,26 @@ function PlayerStats:Clear(player : Player)
 end
 
 function PlayerStats:Reset(player : Player)
-    SessionData[player] = {}
-    for statName, initializer in DEFAULT_SCHEMA do
-        SessionData[player][statName] = initializer()
+    SessionData[player] = DEFAULT_SCHEMA:GetDefault()
+
+    DefaultStatsResolved:Fire(player, SessionData[player])
+end
+
+function PlayerStats:OnDefaultStatsResolved(player : Player, callback : (stats : { [string] : any }) -> nil) : RBXScriptSignal
+    local connection; connection = DefaultStatsResolved:Connect(function(resolvedPlayer, stats)
+        if resolvedPlayer == player then
+            callback(stats)
+            connection:Disconnect()
+        end
+    end)
+
+    if SessionData[player] then
+        connection:Disconnect() -- Disconnect immediately if already resolved
+        task.spawn(function()
+            callback(SessionData[Players.LocalPlayer])
+        end)
     end
+    return connection
 end
 
 --= Initializers =--
@@ -78,8 +114,9 @@ function PlayerStats:Init()
     -- Because various modules might rely on this state, it's not safe for them to call clearPlayerSessionData themselves.
     -- Run with delay to allow time to process and then clear to avoid memory leaks. Not likely worth doing some fancy dependency/roll call system.
     Players.PlayerRemoving:Connect(function(player)
-        task.wait(3)
-        self:Clear(player)
+        task.defer(function()
+            self:Clear(player)
+        end)
     end)
 end
 

--- a/src/Infra/Server/Modules/RequestFunctionHandler/RequestFunctions.luau
+++ b/src/Infra/Server/Modules/RequestFunctionHandler/RequestFunctions.luau
@@ -5,7 +5,7 @@ local Players = game:GetService("Players")
 local ChatService = game:GetService("Chat")
 local Updater = shared.GBMod("Updater")
 local Utilities = shared.GBMod("Utilities")
-local Experiments = shared.GBMod("Experiments")
+local Experiments = shared.GBMod("InternalExperiments")
 
 -- Header comments provide info on request details sent from backend.
 

--- a/src/Infra/Server/Modules/ServerClientInfoHandler.lua
+++ b/src/Infra/Server/Modules/ServerClientInfoHandler.lua
@@ -22,6 +22,7 @@ local GetRemote = shared.GBMod("GetRemote")
 local Signal = shared.GBMod("Signal")
 local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
 local SignalTimeout = shared.GBMod("SignalTimeout") ---@module SignalTimeout
+local Schema = shared.GBMod("Schema") ---@module Schema
 
 --= Types =--
 
@@ -34,12 +35,37 @@ local ClientInfoChangedSignal = Signal.new()
 
 --= Constants =--
 
-local DEFAULT_INFO = {
-    inputType = "unknown" :: "keyboard" | "gamepad" | "touch" | "unknown",
-    device = "unknown" :: "pc" | "mobile" | "console" | "vr" | "unknown",
-    deviceSubType = "unknown" :: "tablet" | "phone" | "xbox" | "playstation" | "unknown",
-    friendsOnline = 0,
-}
+local DefaultInfo = Schema.new({
+    inputType = {
+        default = "unknown",
+        type = "string",
+    },
+    device = {
+        default = "unknown",
+        type = "string",
+    },
+    deviceSubType = {
+        default = "unknown",
+        type = "string",
+    },
+    -- Preserved
+    sessionId = {
+        default = nil,
+        type = "string",
+    },
+    joinTime = {
+        default = nil,
+        type = "number",
+    },
+    totalFriendPlaytime = {
+        default = 0,
+        type = "number",
+    },
+    hasFriendsOnline = {
+        default = false,
+        type = "boolean",
+    }
+})
 
 --= Variables =--
 
@@ -49,6 +75,32 @@ local ClientInfoCache = {}
 
 --= Internal Functions =--
 
+local function UpdateClientInfoCache(player : Player, updatedInfo : { [string] : any })
+    local isNew = false
+    if not ClientInfoCache[player] then
+        ClientInfoCache[player] = DefaultInfo:GetDefault()
+        isNew = true
+    end
+
+    for updatedKey, updatedValue in pairs(updatedInfo) do
+        if not DefaultInfo:HasKey(updatedKey) then
+            return
+        end
+
+        local currentValue = ClientInfoCache[player][updatedKey]
+        if currentValue == updatedValue then
+            continue
+        end
+
+        ClientInfoCache[player][updatedKey] = updatedValue
+        ClientInfoChangedSignal:Fire(player, updatedKey, updatedValue)
+    end
+
+    if isNew then
+        ClientInfoResolvedSignal:Fire(player, ClientInfoCache[player])
+    end
+end
+
 --= API Functions =--
 
 function ServerClientInfoHandler:GetClientInfo(player : Player | number, key : string) : any
@@ -56,28 +108,31 @@ function ServerClientInfoHandler:GetClientInfo(player : Player | number, key : s
         player = Players:GetPlayerByUserId(player)
     end
 
-    if not player or not ClientInfoCache[player] or not ClientInfoCache[player][key] then
-        return DEFAULT_INFO[key]
+    if not player or not ClientInfoCache[player] or ClientInfoCache[player][key] == nil then
+        return DefaultInfo:GetDefaultForKey(key)
     end
     
     return ClientInfoCache[player][key]
 end
 
-function ServerClientInfoHandler:GetDefaultInfo()
-    return table.clone(DEFAULT_INFO)
-end
-
 function ServerClientInfoHandler:OnClientInfoResolved(player : Player, callback : (info : { [string] : any }) -> nil)
-    if ClientInfoCache[player] then
+    if self:IsClientInfoResolved(player) then
         callback(table.clone(ClientInfoCache[player]))
         return
     end
 
-    return ClientInfoResolvedSignal:Connect(function(resolvedPlayer : Player, clientInfo : { [string] : any })
+    local connection
+    connection = ClientInfoResolvedSignal:Connect(function(resolvedPlayer : Player, clientInfo : { [string] : any })
         if resolvedPlayer == player then
-            callback(table.clone(clientInfo))
+            connection:Disconnect()
+
+            if clientInfo then
+                callback(table.clone(clientInfo))
+            end
         end
     end)
+
+    return connection
 end
 
 function ServerClientInfoHandler:OnClientInfoChanged(player : Player, callback : (key : string, value : any) -> nil) : RBXScriptConnection
@@ -90,6 +145,8 @@ end
 
 -- Good way to tell if the client SDK is even initialized.
 function ServerClientInfoHandler:IsClientInfoResolved(player : Player | number) : boolean
+    assert(player, "Player must be provided to check client info resolution.")
+
     if typeof(player) == "number" then
         player = Players:GetPlayerByUserId(player)
     end
@@ -119,38 +176,31 @@ function ServerClientInfoHandler:GetProductPriceForPlayer(player : Player | numb
     end
 end
 
+function ServerClientInfoHandler:UpdateClientData(player : Player | number, key : string, value : any)
+    if typeof(player) == "number" then
+        player = Players:GetPlayerByUserId(player)
+    end
+
+    self:OnClientInfoResolved(player, function()
+        if not player.Parent then
+            return -- Player is not in the game, do not update cache
+        end
+
+        --UpdateClientInfoCache(player, {[key] = value}, true) -- We actually want the client to send this back to us.
+        ClientInfoRemote:FireClient(player, key, value)
+    end)
+end
+
 --= Initializers =--
 function ServerClientInfoHandler:Init()
     Players.PlayerRemoving:Connect(function(player : Player)
-        ClientInfoCache[player] = nil
+        ClientInfoResolvedSignal:Fire(player, nil)
+        task.defer(function()
+            ClientInfoCache[player] = nil
+        end)
     end)
 
-    ClientInfoRemote.OnServerEvent:Connect(function(player : Player, updatedInfo : { [string] : any })
-       
-        local isNew = false
-        if not ClientInfoCache[player] then
-            ClientInfoCache[player] = table.clone(DEFAULT_INFO)
-            isNew = true
-        end
-
-        for updatedKey, updatedValue in pairs(updatedInfo) do
-            if DEFAULT_INFO[updatedKey] == nil then
-                return
-            end
-
-            local currentValue = ClientInfoCache[player][updatedKey]
-            if currentValue == updatedValue then
-                continue
-            end
-
-            ClientInfoCache[player][updatedKey] = updatedValue
-            ClientInfoChangedSignal:Fire(player, updatedKey, updatedValue)
-        end
-
-        if isNew then
-            ClientInfoResolvedSignal:Fire(player, ClientInfoCache[player])
-        end
-    end)
+    ClientInfoRemote.OnServerEvent:Connect(UpdateClientInfoCache)
 end
 
 --= Return Module =--

--- a/src/Infra/Server/Modules/ServerStateReporter.luau
+++ b/src/Infra/Server/Modules/ServerStateReporter.luau
@@ -23,6 +23,7 @@ local Stats = game:GetService("Stats")
 local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
 local MetricCollector = shared.GBMod("MetricCollector") ---@module MetricCollector
 local GetRemote = shared.GBMod("GetRemote") ---@module GetRemote
+local Utilities = shared.GBMod("Utilities") ---@module Utilities
 
 --= Types =--
 type ClientMetricReport = {
@@ -79,7 +80,7 @@ end
 -- Send server state report to GB
 function ServerStateReporter:SendServerStateReport()
     local serverStateReport = self:PrepareServerStateReport()
-    local serverId = if RunService:IsStudio() then HttpService:GenerateGUID(false) else game.JobId
+    local serverId = Utilities.getServerId()
 
     GBRequests:GBRequest(`v1/servers/roblox/{serverId}`, serverStateReport)
 end

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -203,9 +203,8 @@ function Updater:Init()
 				Utilities.GBWarn("Attempting to establish connection...")
 				newConfigs = fetchConfigs()
 			until newConfigs
-			print("Connection with Gamebeast re-established! Loading newest configs...")
-		else
-			print("Backup configs loaded successfully!")
+
+			Utilities.GBWarn("Connection established, fetching configurations...")
 		end
 	end
 

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -19,25 +19,22 @@
 local Updater = { }
 
 --= Roblox Services =--
-local DataStoreService = game:GetService("DataStoreService")
-local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
 local RunService = game:GetService("RunService")
 
 --= Dependencies =--
 
 local GBRequests = shared.GBMod("GBRequests")
-local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module EngagementMarkers
 local Experiments = shared.GBMod("Experiments") ---@module Experiments
 local Utilities = shared.GBMod("Utilities")
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local Signal = shared.GBMod("Signal")
+local DatatstoreBackup = shared.GBMod("DatastoreBackup") ---@module DatastoreBackup
 local MetaData = shared.GBMod("MetaData") ---@module MetaData
 
 --= Types =--
 
 --= Constants =--
-
-local BACKUP_STORE_KEY = (RunService:IsStudio() and "Studio" or "") .. "GBConfigBackup"
 
 --[[
 	When config is being applied, this controls the maximum amount of seconds
@@ -50,8 +47,6 @@ local BACKUP_STORE_KEY = (RunService:IsStudio() and "Studio" or "") .. "GBConfig
 local MAX_INITIAL_EXPERIMENT_ASSIGNMENT_WAIT_TIME = 5
 
 --= Object References =--
-
-local BackupConfigStore = DataStoreService:GetDataStore(BACKUP_STORE_KEY)
 
 --= Variables =--
 
@@ -146,9 +141,7 @@ end
 
 -- In the unlikely case GB is down, fall back on Roblox datastores
 function Updater:GetBackupConfigs()
-	local configs, success = Utilities.promiseReturn(2, function()
-		return BackupConfigStore:GetAsync(BACKUP_STORE_KEY)
-	end)
+	local success, configs = DatatstoreBackup:Get("Configs")
 	
 	if not success then
 		Utilities.GBWarn("Couldn't get configs from backup. Attempting to re-establish connection with Gamebeast...")
@@ -168,9 +161,7 @@ function Updater:SaveConfigsToBackup(newConfigs)
 	local newBackupConfigs = Utilities.recursiveCopy(newConfigs)
 	newBackupConfigs.GBConfigs.Experiments = nil
 
-	Utilities.promiseReturn(1, function()
-		BackupConfigStore:SetAsync(BACKUP_STORE_KEY, newBackupConfigs)
-	end)
+	DatatstoreBackup:Set("Configs", newBackupConfigs)
 end
 
 

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -25,7 +25,7 @@ local RunService = game:GetService("RunService")
 --= Dependencies =--
 
 local GBRequests = shared.GBMod("GBRequests")
-local Experiments = shared.GBMod("Experiments") ---@module Experiments
+local Experiments = shared.GBMod("InternalExperiments") ---@module InternalExperiments
 local Utilities = shared.GBMod("Utilities")
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local Signal = shared.GBMod("Signal")

--- a/src/Infra/Server/Modules/Updater.luau
+++ b/src/Infra/Server/Modules/Updater.luau
@@ -8,7 +8,10 @@
 	Updater.luau
 	
 	Description:
-		No description provided.
+		Handles updating the internal configurations of the Gamebeast SDK
+		based on the latest configurations received from the Gamebeast server.
+		It also manages experiment assignments and applies configurations
+		to players and the server.
 	
 --]]
 

--- a/src/Infra/Server/Modules/Utilities/init.luau
+++ b/src/Infra/Server/Modules/Utilities/init.luau
@@ -11,15 +11,12 @@ local MessagingServiceDebugCache = {} :: {[string] : number}
 local utilities = {}
 
 -- Central function for warning messages across SDK. Indicates Gamebeast as warning source and allows for output settings.
-utilities.GBWarn = function(message)
+utilities.GBWarn = function(...)
 	if DataCache:Get("Settings").sdkWarningsEnabled then
+		warn("GamebeastSDK:", ...)
 		if DataCache:Get("Settings").includeWarningStackTrace then
-			message = debug.traceback("GamebeastSDK: ".. message)
-		else
-			message = "GamebeastSDK: ".. message
+			warn("GamebeastSDK Traceback:", debug.traceback())
 		end
-		
-		warn(message)
 	end
 end
 

--- a/src/Infra/Server/Modules/Utilities/init.luau
+++ b/src/Infra/Server/Modules/Utilities/init.luau
@@ -3,6 +3,8 @@
 
 local marketplaceService = game:GetService("MarketplaceService")
 local messagingService = game:GetService("MessagingService")
+local httpService = game:GetService("HttpService")
+local runService = game:GetService("RunService")
 
 local DataCache = shared.GBMod("DataCache")
 
@@ -195,6 +197,15 @@ function utilities.getValueAtPath(root: any, path: {string}): any
 		value = value[pathSegment]
 	end
 	return value
+end
+
+local serverId = if runService:IsStudio()
+	then `studio:{httpService:GenerateGUID(false):lower()}`
+	else game.JobId
+
+--- Returns the server's ID in live games, or a generated one for each Studio test session (prefixed with `studio:`).
+function utilities.getServerId(): string
+	return serverId
 end
 
 -- Wrapper for player added that ensures players that joined before the signal was attached get passed through the callback.

--- a/src/Infra/Server/Public/Configs.lua
+++ b/src/Infra/Server/Public/Configs.lua
@@ -34,11 +34,11 @@ local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfi
 
 --= API Functions =--
 
-function Configs:Get(path : string | { string })
+function Configs:Get(path : string | { string }) : any
     return InternalConfigs:Get(nil, path)
 end
 
-function Configs:GetForPlayer(player: Player, path: string | {string})
+function Configs:GetForPlayer(player: Player, path: string | {string}) : any
     return InternalConfigs:Get(player, path)
 end
 
@@ -77,7 +77,7 @@ function Configs:OnChangedForPlayer(player: Player, targetConfig: string | {stri
     return InternalConfigs:OnChanged(player, targetConfig, callback)
 end
 
-function Configs:OnReady(callback : (configs : any) -> ()) : RBXScriptSignal
+function Configs:OnReady(callback : (configs : any) -> ()) : RBXScriptConnection
     return InternalConfigs:OnReady(callback)
 end
 

--- a/src/Infra/Server/Public/Configs.lua
+++ b/src/Infra/Server/Public/Configs.lua
@@ -5,7 +5,7 @@
     Configs.lua
     
     Description:
-        No description provided.
+        Server-side API for accessing and observing configuration data.
     
 --]]
 

--- a/src/Infra/Server/Public/Events.lua
+++ b/src/Infra/Server/Public/Events.lua
@@ -37,11 +37,11 @@ function Events:GetEventData(eventName : string)
     return InternalConfigs:GetEventData(eventName)
 end
 
-function Events:OnStart(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptSignal
+function Events:OnStart(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptConnection
     return EventsManager:OnStart(eventName, callback)
 end
 
-function Events:OnEnd(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptSignal
+function Events:OnEnd(eventName : string, callback : (eventInfo : { [string] : any }) -> ()) : RBXScriptConnection
     return EventsManager:OnEnd(eventName, callback)
 end
 

--- a/src/Infra/Server/Public/Events.lua
+++ b/src/Infra/Server/Public/Events.lua
@@ -5,7 +5,7 @@
     Events.lua
     
     Description:
-        No description provided.
+        Public API for managing definined events.
     
 --]]
 

--- a/src/Infra/Server/Public/Experiments.luau
+++ b/src/Infra/Server/Public/Experiments.luau
@@ -1,0 +1,19 @@
+local Experiments = {}
+
+local InternalExperiments = shared.GBMod("InternalExperiments")
+local Types = require(script.Parent.Parent.Parent.Types)
+
+--[[
+    Returns information about the experiment group currently assigned to the player, if any.
+]]
+function Experiments:GetGroupForPlayer(player: Player): Types.ExperimentGroupMetadata?
+    local assignedGroupId = InternalExperiments.AssignedGroupIdByPlayer[player]
+        or InternalExperiments.AssignedServerGroupId
+    if not assignedGroupId then
+        return nil
+    end
+
+    return InternalExperiments:GetActiveGroupMetadata(assignedGroupId)
+end
+
+return Experiments

--- a/src/Infra/Server/Public/Markers.lua
+++ b/src/Infra/Server/Public/Markers.lua
@@ -35,11 +35,11 @@ local PurchaseAnalytics = shared.GBMod("PurchaseAnalytics") ---@module PurchaseA
 
 --= API Functions =--
 
-function Markers:SendMarker(markerType : string, value : number | {[string] : any}, position : Vector3?)
+function Markers:SendMarker(markerType : string, value : any | {[string] : any}, position : Vector3?)
     EngagementMarkers:FireMarker(markerType, value, {position = position})
 end
 
-function Markers:SendPlayerMarker(player : Player, markerType : string, value : number | {[string] : any}, position : Vector3?)
+function Markers:SendPlayerMarker(player : Player, markerType : string, value : any | {[string] : any}, position : Vector3?)
     EngagementMarkers:FireMarker(markerType, value, {player = player, position = position})
 end
 

--- a/src/Infra/Server/Public/Markers.lua
+++ b/src/Infra/Server/Public/Markers.lua
@@ -5,7 +5,7 @@
     Markers.lua
     
     Description:
-        No description provided.
+        Server-side API for sending engagement markers.
     
 --]]
 

--- a/src/Infra/Shared/Modules/Cleaner.lua
+++ b/src/Infra/Shared/Modules/Cleaner.lua
@@ -5,7 +5,7 @@
     Cleaner.lua
     
     Description:
-        No description provided.
+        A utility module for managing and cleaning up objects and connections.
     
 --]]
 

--- a/src/Infra/Shared/Modules/GetRemote.luau
+++ b/src/Infra/Shared/Modules/GetRemote.luau
@@ -5,7 +5,7 @@
     GetRemote.luau
     
     Description:
-        No description provided.
+        A utility module for retrieving or creating remote functions or events.
     
 --]]
 

--- a/src/Infra/Shared/Modules/Schema.lua
+++ b/src/Infra/Shared/Modules/Schema.lua
@@ -1,0 +1,105 @@
+--[[
+    The Gamebeast SDK is Copyright © 2023 Gamebeast, Inc. to present.
+    All rights reserved.
+
+    Schema.lua
+    
+    Description:
+        No description provided.
+    
+--]]
+
+--= Root =--
+
+local Schema = {}
+Schema.__index = Schema
+
+--= Roblox Services =--
+
+--= Dependencies =--
+
+--= Types =--
+
+--= Object References =--
+
+--= Constants =--
+
+--= Variables =--
+
+--= Internal Functions =--
+
+--= Constructor =--
+
+function Schema.new(structure : {[string] : {default : any | () -> any, type : string | {string}}})
+    local self = setmetatable({}, Schema)
+
+    for _, valueSchema in structure do
+        if type(valueSchema.type) == "string" then
+            valueSchema.type = {valueSchema.type} -- Ensure type is a table of types
+        end
+
+        local dictonary = {}
+        for _, typeName in ipairs(valueSchema.type) do
+            dictonary[typeName] = true -- Create a dictionary for fast type checking
+        end
+
+        valueSchema.type = dictonary
+    end
+
+    self._structure = structure
+
+    return self
+end
+
+--= Methods =--
+
+function Schema:GetDefault() : {[string] : any}
+    local defaults = {}
+
+    for key, value in pairs(self._structure) do
+        if type(value.default) == "function" then
+            defaults[key] = value.default()
+        else
+            defaults[key] = value.default
+        end
+    end
+
+    return defaults
+end
+
+function Schema:GetDefaultForKey(key : string) : any
+    local field = self._structure[key]
+    if not field then
+        error("Key '" .. key .. "' does not exist in schema.")
+    end
+
+    if type(field.default) == "function" then
+        return field.default()
+    else
+        return field.default
+    end
+end
+
+function Schema:HasKey(key : string) : boolean
+    return self._structure[key] ~= nil
+end
+
+function Schema:Sanitize(data : {[string] : any})
+    for key, value in pairs(data) do
+        if self._structure[key] == nil then
+            data[key] = nil -- Remove keys not in the schema
+        end
+
+        if not self._structure[key].type[type(value)] then
+            data[key] = nil -- Remove keys with incorrect type
+        end
+    end
+
+    return data
+end
+
+function Schema:Destroy()
+    -- Nothing to clean up in this case
+end
+
+return Schema

--- a/src/Infra/Shared/Modules/Signal/SignalConnection.lua
+++ b/src/Infra/Shared/Modules/Signal/SignalConnection.lua
@@ -4,7 +4,7 @@
     SignalConnection.lua
     
     Description:
-        No description provided.    
+        Emulates a RBXScriptConnection for signals, allowing for connection management
 --]]
 
 --= Root =--

--- a/src/Infra/Types.luau
+++ b/src/Infra/Types.luau
@@ -25,8 +25,11 @@ export type ConfigsService = {
 	Get : (self : ConfigsService, path : string | { string }) -> any,
 	Observe : (self : ConfigsService, targetConfig : string | { string }, callback : (newValue : any, oldValue : any) -> ()) -> RBXScriptConnection,
 	OnChanged : (self : ConfigsService, targetConfig : string | {string}, callback : (newValue : any, oldValue : any) -> ()) -> RBXScriptConnection,
-	OnReady : (self : ConfigsService, callback : (configs : any) -> ()) -> RBXScriptSignal,
+	OnReady : (self : ConfigsService, callback : (configs : any) -> ()) -> RBXScriptConnection,
 	IsReady : (self : ConfigsService) -> boolean,
+	GetForPlayer : (self : ConfigsService, player : Player, path : string | { string }) -> any,
+	ObserveForPlayer : (self : ConfigsService, player : Player, targetConfig : string | { string }, callback : (newValue : any, oldValue : any) -> ()) -> RBXScriptConnection,
+	OnChangedForPlayer : (self : ConfigsService, player : Player, targetConfig : string | {string}, callback : (newValue : any, oldValue : any) -> ()) -> RBXScriptConnection,
 }
 
 export type MarkersService = {
@@ -46,6 +49,6 @@ export type EventsService = {
 }
 
 
-export type Service = ConfigsService | MarkersService | EventsService
+export type Service = ConfigsService | MarkersService | EventsService | JobsService
 
 return true

--- a/src/Infra/Types.luau
+++ b/src/Infra/Types.luau
@@ -50,7 +50,14 @@ export type EventsService = {
 	OnEnd : (self : EventsService, event : string, callback : (data : JSON) -> ()) -> RBXScriptConnection,
 }
 
+export type ExperimentsService = {
+	GetGroupForPlayer: (self: ExperimentsService, player: Player) -> ExperimentGroupMetadata?,
+}
+export type ExperimentGroupMetadata = {
+	experimentName: string,
+	groupName: string,
+}
 
-export type Service = ConfigsService | MarkersService | EventsService | JobsService
+export type Service = ConfigsService | MarkersService | EventsService | JobsService | ExperimentsService
 
 return true

--- a/src/Infra/Types.luau
+++ b/src/Infra/Types.luau
@@ -5,6 +5,8 @@ type SDKSettings = {
 	includeWarningStackTrace : boolean,
 	-- Enables SDK debug messages for internal state changes, etc.
 	sdkDebugEnabled : boolean,
+	-- Custom URL for the SDK, if any.
+	customUrl : string | nil,
 }
 export type ServerSetupConfig = {
 	key : string | Secret,

--- a/src/init.lua
+++ b/src/init.lua
@@ -31,6 +31,7 @@ export type ConfigsService = Types.ConfigsService
 export type MarkersService = Types.MarkersService
 export type JobsService = Types.JobsService
 export type EventsService = Types.EventsService
+export type ExperimentsService = Types.ExperimentsService
 
 type ModuleData = {
 	Name : string,

--- a/src/init.lua
+++ b/src/init.lua
@@ -50,6 +50,7 @@ local DEFAULT_SETTINGS = {
 	sdkWarningsEnabled = true,
 	includeWarningStackTrace = false,
 	sdkDebugEnabled = false,
+	customUrl = nil, -- Custom domain for the SDK, if any
 }
 
 --= Object References =--


### PR DESCRIPTION
Features:

- Play Session is now preserved through teleports to places within the same universe
- `PlaceTeleport` default marker
- Markers sent with a single value can now be any JSON-compatible data type instead of only numbers.
- Markers that fail to get sent to Gamebeast will now be saved and retried by the host server when services are available.
- Added "ExperimentsService"
- Added "fromReceipt" argument to default `Purchase` marker

Fixes:

- Host election "MessagingService" usage has been further reduced.
- Added "...ForPlayer" types to `ConfigsService`
- Added `JobsService` to types
- Studio CCU should now get counted correctly