### PR TITLE
v0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,27 @@
-# RobloxSDK
+# [Gamebeast](https://gamebeast.gg/) Roblox SDK
+*Documentaion: https://docs.gamebeast.gg/*
 
-Documentaion: https://docs.gamebeast.gg/
+This SDK is intended for use with the Roblox platform.
+
+## What is Gamebeast?
+Gamebeast specializes in providing real-time analytics and tools for user engagement, allowing developers to make data-driven decisions to enhance their games.
+
+From the Gamebeast dashboard, developers can automatically detect player pain points and make live updates to their experience. By making adjustments that are seamless to their users, the experience is optimized for engagement - creating a boost in developer revenue.
+
+
+Some of the key features Gamebeast provides include:
+- **Remote Configurations**: Easily manage and update configurations in real-time without needing to push new game versions.
+- **Engagement Markers**: Track player interactions and events to understand how players are engaging with your experience.
+- **User Management**: Simplified user management to easily track and manage players in your experience.
+- **Experiments**: Run A/B tests to optimize your experience based on player behavior.
+- **Funnels**: Visualize player flow through your experience to identify drop-off points and optimize player retention.
+- **Heatmaps**: Visualize player interactions and engagement hotspots in your experience.
+- **Jobs**: Schedule and manage background tasks to automate processes in your experience.
+
+
+## Installation
+To get started with Gamebeast, sign up at https://dashboard.gamebeast.gg/
+
+Gamebeast can be installed directly to Roblox Studio through our Roblox Plugin, or via Roblox focused package managers such as Wally. 
+
+Please visit https://docs.gamebeast.gg/Roblox/Installation for more details.

--- a/src/Infra/Client/Modules/ClientFriendHandler.lua
+++ b/src/Infra/Client/Modules/ClientFriendHandler.lua
@@ -63,9 +63,9 @@ local function UpdateFriendCache()
     local hasFriendsOnline = ClientInfoHandler:GetClientInfo("hasFriendsOnline") or false
 
     if hasFriendsOnline == true and foundFriendsOnline <= 0 then
-        ClientInfoHandler:UpdateClientInfo("totalFriendPlaytime", (ClientInfoHandler:GetClientInfo("totalFriendPlaytime") or 0) + os.clock() - (ClientInfoHandler:GetClientInfo("friendClockStart")))
+        ClientInfoHandler:UpdateClientInfo("totalFriendPlaytime", (ClientInfoHandler:GetClientInfo("totalFriendPlaytime") or 0) + os.time() - (ClientInfoHandler:GetClientInfo("friendClockStart")))
     elseif foundFriendsOnline > 0 and hasFriendsOnline == false then
-        ClientInfoHandler:UpdateClientInfo("friendClockStart", os.clock())
+        ClientInfoHandler:UpdateClientInfo("friendClockStart", os.time())
     end
 
     FriendsOnline = foundFriendsOnline

--- a/src/Infra/MetaData.lua
+++ b/src/Infra/MetaData.lua
@@ -1,5 +1,5 @@
 -- Contains version information for the SDK
 
 return {
-    version = "v0.6.1"
+    version = "v0.7.0"
 }

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -30,6 +30,7 @@ local GBRequests = shared.GBMod("GBRequests") ---@module GBRequests
 local FailedMarkers = shared.GBMod("FailedMarkers") ---@module FailedMarkers
 local InternalConfigs = shared.GBMod("InternalConfigs") ---@module InternalConfigs
 local Experiments = shared.GBMod("InternalExperiments") ---@module InternalExperiments
+local SignalConnection = shared.GBMod("SignalConnection") ---@module SignalConnection
 local LocalizationCache = shared.GBMod("LocalizationCache") ---@module LocalizationCache
 local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@module ServerClientInfoHandler
 
@@ -307,16 +308,37 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 			end
 		end
 
+		-- Check for custom tasks
+		if metaData.tasks then
+			for taskName, taskFunction in metaData.tasks do
+				local connection = SignalConnection.new(function()
+					completeTask(taskName)
+				end)
+
+				addTask(taskName, connection)
+
+				task.spawn(function()
+					taskFunction(value)
+					connection:Disconnect()
+					completeTask(taskName)
+				end)
+			end
+		end
+
 		-- Stop wating after some time if tasks are not resolved
 		local dataFetchTimer = Timer.new(CLIENT_DATA_TIMEOUT)
 		pendingMarkerData.pendingCleaner:Add(dataFetchTimer)
 		pendingMarkerData.pendingCleaner:Add(dataFetchTimer:OnEnd(function()
+			if not pendingMarkerData.tasks["clientInfo"] then
+				return
+			end
+
 			if not ServerClientInfoHandler:IsClientInfoResolved(player) and ClientInfoWarned == false then
 				Utilities.GBWarn("Failed to resolve client info, did you forget to :Setup() Gamebeast SDK on the client?")
 				ClientInfoWarned = true
 			end
 
-			resolved()
+			completeTask("clientInfo")
 		end))
 
 		if player then -- Ensure marker gets fired with device info on timeout or bind to close

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -214,6 +214,7 @@ function EngagementMarkers:_createMarker(source : "server" | "client" | "sdk", m
 		["markerId"] = HttpService:GenerateGUID(false),
 		["timestamp"] = metaData.timestampOverride or DateTime.now().UnixTimestampMillis,
 		["type"] = markerType,
+		["serverId"] = Utilities.getServerId(),
 		["userId"] = player and player.UserId, 
 		["sessionId"] = nil, -- Resolved later
 		["value"] = value,

--- a/src/Infra/Server/Modules/EngagementMarkers.luau
+++ b/src/Infra/Server/Modules/EngagementMarkers.luau
@@ -52,7 +52,8 @@ local ALLOWED_VALUE_TYPES = {
 }
 local DROP_MARKER_CODES = {
 	["INVALID_MARKERS"] = true,
-	["SUBSCRIPTION_LIMIT_EXCEEDED"] = true
+	["SUBSCRIPTION_LIMIT_EXCEEDED"] = true,
+	["SUBSCRIPTION_UNPAID"] = true
 }
 
 --= Variables =--

--- a/src/Infra/Server/Modules/GBRequests.luau
+++ b/src/Infra/Server/Modules/GBRequests.luau
@@ -114,6 +114,7 @@ end
 
 --YEILDS 
 function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any}, maxRetries : number?) : (boolean, any?)
+	local authKey = YeildForKey() -- Will wait for Key and Settings to be set
 	local GBDomain, requestMethod = GetEndpointForRequest(requestRoute)
 	
 	if not GBDomain or not requestMethod then
@@ -126,7 +127,6 @@ function GBRequests:GBRequestAsync(requestRoute : string, args : {[string] : any
 	local requestBody
 	args = args or {}
 
-	local authKey = YeildForKey()
 
 	-- Define relevant headers. Backend enforces header presence unless specified.
 	local isStudio = RunService:IsStudio()

--- a/src/Infra/Server/Modules/InternalExperiments.luau
+++ b/src/Infra/Server/Modules/InternalExperiments.luau
@@ -610,7 +610,7 @@ function executeAssignmentRequest()
 		end
 	end
 
-	if (assignmentResponse.targetType == "gameserver") and assignmentResponse.gameserverGroupId then
+	if assignmentResponse.targetType == "gameserver" then
 		setAssignedServerGroupId(assignmentResponse.gameserverGroupId)
 
 		-- Clear previous per-player assignments, if any
@@ -618,7 +618,7 @@ function executeAssignmentRequest()
 			setAssignedPlayerGroupId(player, nil)
 		end
 
-	elseif (assignmentResponse.targetType == "player") and assignmentResponse.playerIdsByGroupId then
+	elseif assignmentResponse.targetType == "player" then
 		local assignedPlayerIdSet: {[number]: true} = {}
 		for groupIdString, groupPlayerIds in assignmentResponse.playerIdsByGroupId do
 			local groupId = tonumber(groupIdString) :: number

--- a/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/PurchaseAnalytics.luau
@@ -199,7 +199,8 @@ function PurchaseAnalytics:Init()
 	end)
 
 	-- Purchase records handler for products
-	MarketplaceService.PromptProductPurchaseFinished:Connect(function(playerId : number, productId : number, wasPurchased : boolean)
+	--NOTE: Disabled due to PromptProductPurchaseFinished being unreliable. Too many false positives.
+	--[[MarketplaceService.PromptProductPurchaseFinished:Connect(function(playerId : number, productId : number, wasPurchased : boolean)
 		if DevProductEventDebounce[playerId] then
 			return
 		end
@@ -211,7 +212,7 @@ function PurchaseAnalytics:Init()
 			task.wait(3)
 			DevProductEventDebounce[playerId] = nil
 		end
-	end)
+	end)]]
 
 	Players.PlayerRemoving:Connect(FlushProductPurchaseCache)
 end

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -16,9 +16,11 @@ local SessionMarkers = { }
 
 --= Roblox Services =--
 
+local HttpService = game:GetService("HttpService")
 local Players = game:GetService("Players")
 local PolicyService = game:GetService("PolicyService")
 local AssetService = game:GetService("AssetService")
+local RunService = game:GetService("RunService")
 
 --= Dependencies =--
 
@@ -34,16 +36,43 @@ local ServerClientInfoHandler = shared.GBMod("ServerClientInfoHandler") ---@modu
 
 --= Constants =--
 
+local IS_STUDIO = RunService:IsStudio()
+local DEFAULT_FILTER = {
+	--["GB_SOURCE"] = "string",
+}
+
 --= Variables =--
 
 local LastCharPositions = {}
 local PlacesInUniverse = {}
+local LaunchDataFilter = DEFAULT_FILTER
 
 --= Public Variables =--
 
 --= Internal Functions =--
 
 --= API Functions =--
+
+function SessionMarkers:SetLaunchDataFilter(filterArgs : {[string] : string | (any) -> boolean})
+	local argCount = 0
+	for _, _ in pairs(filterArgs) do
+		argCount += 1
+	end
+
+	if argCount > 4 then
+		error("LaunchDataFilter can only have up to 4 arguments, got " .. argCount)
+	end
+
+	for key, value in pairs(DEFAULT_FILTER) do
+		if filterArgs[key] ~= nil then
+			error(`LaunchDataFilter cannot override default key "{key}"`)
+		end
+		
+		filterArgs[key] = value
+	end
+
+	LaunchDataFilter = filterArgs
+end
 
 --= Initializers =--
 function SessionMarkers:Init()
@@ -63,11 +92,69 @@ function SessionMarkers:Init()
 				return PolicyService:GetPolicyInfoForPlayerAsync(player)
 			end)
 
+			-- Populate referrer data if available
+			local isFriend;
+			if joinData.ReferredByPlayerId then
+				isFriend = Utilities.promiseReturn(1, function()
+					return player:IsFriendsWith(joinData.ReferredByPlayerId)
+				end)
+			end
+
 			local loginArgs = {
-				policyInfo = policyInfo
+				policyInfo = policyInfo,
+				publicServer = game.PrivateServerId == "",
+				metadata = {},
+				referrer = if isFriend ~= nil then {
+					type = "friend",
+					id = joinData.ReferredByPlayerId
+				} else nil
 			}
 
-			EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil})
+			EngagementMarkers:SDKMarker("Login", loginArgs, {player = player, position = nil,
+				-- Add task to wait for join data
+				tasks = {
+					launchData = function(args)
+						if IS_STUDIO then
+							return
+						end
+
+
+						local launchData = joinData.LaunchData
+						local attemptCount = 0
+
+						while attemptCount < 10 and launchData == "" do
+							task.wait(0.5)
+							attemptCount += 1
+
+							local latestJoinData = player:GetJoinData()
+							launchData = latestJoinData.LaunchData
+						end
+
+						if launchData ~= "" then
+							local success, launchDataJson = pcall(function()
+								return HttpService:JSONDecode(launchData)
+							end)
+
+							if success then
+								for key, filter in LaunchDataFilter do
+									if type(filter) == "function" then
+										local valid = filter(launchDataJson[key])
+										if valid == false then
+											launchDataJson[key] = nil
+										end
+									elseif type(launchDataJson[key]) ~= filter then
+										launchDataJson[key] = nil
+									end
+								end
+
+								args.metadata = launchDataJson
+							end
+						else
+							args.metadata = {}
+						end
+					end
+				}
+			})
 
 			PlayerStats:OnDefaultStatsResolved(function()
 				ServerClientInfoHandler:UpdateClientData(player, "joinTime", PlayerStats:GetStat(player, "join_time"))

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -155,10 +155,10 @@ function SessionMarkers:Init()
 		-- Compute session length in addition to backend for reasons(?)
 		local clientJoinTime = ServerClientInfoHandler:GetClientInfo(player, "joinTime")
 		local sessionLength = Utilities.roundNum(os.time() - (clientJoinTime or PlayerStats:GetStat(player, "join_time")), 0.1)
-		local friendPlaytimePercent = SocialHandler:GetTotalFriendPlaytime(player)
+		local friendPlaytime = SocialHandler:GetTotalFriendPlaytime(player)
 		local args = {
 			["sessionLength"] = sessionLength,
-			["sessionLengthPercentageWithFriends"] = if friendPlaytimePercent then Utilities.roundNum(friendPlaytimePercent/sessionLength, 0.01) else nil
+			["sessionLengthPercentageWithFriends"] = if friendPlaytime then Utilities.roundNum(friendPlaytime/sessionLength, 0.01) else nil
 		}
 
 		local teleportingToPlace = PlayerStats:GetStat(player, "teleporting_to")

--- a/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
+++ b/src/Infra/Server/Modules/InternalMarkers/SessionMarkers.luau
@@ -53,27 +53,6 @@ local LaunchDataFilter = DEFAULT_FILTER
 
 --= API Functions =--
 
-function SessionMarkers:SetLaunchDataFilter(filterArgs : {[string] : string | (any) -> boolean})
-	local argCount = 0
-	for _, _ in pairs(filterArgs) do
-		argCount += 1
-	end
-
-	if argCount > 4 then
-		error("LaunchDataFilter can only have up to 4 arguments, got " .. argCount)
-	end
-
-	for key, value in pairs(DEFAULT_FILTER) do
-		if filterArgs[key] ~= nil then
-			error(`LaunchDataFilter cannot override default key "{key}"`)
-		end
-		
-		filterArgs[key] = value
-	end
-
-	LaunchDataFilter = filterArgs
-end
-
 --= Initializers =--
 function SessionMarkers:Init()
 	Utilities:OnPlayerAdded(function(player : Player)
@@ -103,9 +82,8 @@ function SessionMarkers:Init()
 			local loginArgs = {
 				policyInfo = policyInfo,
 				publicServer = game.PrivateServerId == "",
-				metadata = {},
-				referrer = if isFriend ~= nil then {
-					type = "friend",
+				referrer = if joinData.ReferredByPlayerId then {
+					type = if isFriend then "friend" else "user",
 					id = joinData.ReferredByPlayerId
 				} else nil
 			}
@@ -147,10 +125,17 @@ function SessionMarkers:Init()
 									end
 								end
 
-								args.metadata = launchDataJson
+								if not args.referrer then
+									args.referrer = {
+										type = "deeplink",
+										id = nil,
+									}
+								end
+								
+								--args.metadata = launchDataJson
 							end
 						else
-							args.metadata = {}
+							--args.metadata = {}
 						end
 					end
 				}

--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -74,14 +74,6 @@ function SocialHandler:Init()
     local function playerAdded(player : Player)
         local cacheEntry = CreateCacheEntry(player)
 
-        local joinData = player:GetJoinData()
-        if joinData.ReferredByPlayerId and joinData.ReferredByPlayerId > 0 then
-            EngagementMarkers:SDKMarker("JoinedUser", {
-                userId = joinData.ReferredByPlayerId,
-                isFriend = player:IsFriendsWith(joinData.ReferredByPlayerId),
-            }, { player = player })
-        end
-
         cacheEntry.Cleaner:Add(ServerClientInfoHandler:OnClientInfoChanged(player, function(key, _)
             if key == "friendClockStart" then
                 cacheEntry.LastClientUpdate = os.clock()

--- a/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
+++ b/src/Infra/Server/Modules/InternalMarkers/SocialHandler.lua
@@ -63,7 +63,7 @@ function SocialHandler:GetTotalFriendPlaytime(player : Player) : number?
     local totalTime = ServerClientInfoHandler:GetClientInfo(player, "totalFriendPlaytime")
 
     if hasFriendsOnline then
-        return totalTime + (os.clock() - cachedData.LastClientUpdate)
+        return totalTime + (os.time() - cachedData.LastClientUpdate)
     else
         return totalTime
     end
@@ -76,7 +76,7 @@ function SocialHandler:Init()
 
         cacheEntry.Cleaner:Add(ServerClientInfoHandler:OnClientInfoChanged(player, function(key, _)
             if key == "friendClockStart" then
-                cacheEntry.LastClientUpdate = os.clock()
+                cacheEntry.LastClientUpdate = os.time()
             end
         end))
 

--- a/src/Infra/Server/Modules/RequestFunctionHandler/RequestFunctions.luau
+++ b/src/Infra/Server/Modules/RequestFunctionHandler/RequestFunctions.luau
@@ -26,7 +26,7 @@ requestFunctions.funcs = {
 	-- host_only: true
 	-- async: true
 	["Ban"] = function(args)
-		local userIdentifier = args.user_identifier
+		local userIdentifier = args.playerId
 		local success
 		
 		-- We support UserIds + usernames from the dashboard
@@ -47,11 +47,11 @@ requestFunctions.funcs = {
 		end
 		
 		-- If nil, we use -1 (Ban API representation of perm)
-		local banTime = args.ban_duration or -1
+		local banTime = if args.unbanAt then args.unbanAt - (os.time() * 1000) else -1
 		
 		-- Execute ban action
 		local _, success = Utilities.promiseReturn(2, function()
-			Players:BanAsync({UserIds = {userIdentifier}, Duration = banTime, DisplayReason = args.reason, PrivateReason = args.private_reason, ExcludeAltAccounts = args.exclude_alts})
+			Players:BanAsync({UserIds = {userIdentifier}, Duration = banTime, DisplayReason = args.reason, PrivateReason = args.privateReason or args.reason, ExcludeAltAccounts = args.excludeAlts})
 		end)
 		
 		if not success then
@@ -62,7 +62,7 @@ requestFunctions.funcs = {
 	-- host_only: true
 	-- async: true
 	["Unban"] = function(args)
-		local userIdentifier = args.user_identifier
+		local userIdentifier = args.playerId
 		local success
 
 		-- We support UserIds + usernames from the dashboard
@@ -84,7 +84,7 @@ requestFunctions.funcs = {
 		
 		-- Execute unban action
 		local _, success = Utilities.promiseReturn(2, function()
-			Players:UnbanAsync({UserIds = {userIdentifier}})
+			Players:UnbanAsync({UserIds = {userIdentifier}, ApplyToUniverse = true})
 		end)
 
 		if not success then
@@ -95,7 +95,7 @@ requestFunctions.funcs = {
 	-- host_only: false
 	-- async: true
 	["Kick"] = function(args)
-		local userIdentifier = args.user_identifier
+		local userIdentifier = args.playerId
 		-- We support UserIds + usernames from the dashboard
 		if tonumber(userIdentifier) then
 			--

--- a/src/Infra/Server/Modules/Utilities/init.luau
+++ b/src/Infra/Server/Modules/Utilities/init.luau
@@ -9,6 +9,7 @@ local runService = game:GetService("RunService")
 local DataCache = shared.GBMod("DataCache")
 
 local MessagingServiceDebugCache = {} :: {[string] : number}
+local MessagingServiceRequestTimestamps = {}
 
 local utilities = {}
 
@@ -172,8 +173,25 @@ utilities.publishMessage = function(channel, message)
 		messagingService:PublishAsync(channel, message)
 	end)
 
+	-- Measure request rate for potential throttling issues
+	table.insert(MessagingServiceRequestTimestamps, {Time = os.clock()})
+	if #MessagingServiceRequestTimestamps > 100 then
+		table.remove(MessagingServiceRequestTimestamps, 1)
+	end
+
+	local total = #MessagingServiceRequestTimestamps
+	local avg = 0
+	
+	for _, req in MessagingServiceRequestTimestamps do
+		if os.clock() - req.Time < 60 then
+			avg += 1
+		end
+	end
+
+	avg /= total
+
 	if not success then
-		utilities.GBWarn(`Failed to publish message to channel: {channel} (Total count: {MessagingServiceDebugCache[channel]}) with error: {errorMessage}`)
+		utilities.GBWarn(`Failed to publish message to channel: {channel} (Req count on channel: {MessagingServiceDebugCache[channel]}, Avg. total req/min: {math.round(avg)}) with error: {errorMessage}`)
 	end
 end
 

--- a/src/Infra/Server/Modules/Utilities/init.luau
+++ b/src/Infra/Server/Modules/Utilities/init.luau
@@ -10,6 +10,7 @@ local DataCache = shared.GBMod("DataCache")
 
 local MessagingServiceDebugCache = {} :: {[string] : number}
 local MessagingServiceRequestTimestamps = {}
+local LastMessageTime = nil
 
 local utilities = {}
 
@@ -174,24 +175,26 @@ utilities.publishMessage = function(channel, message)
 	end)
 
 	-- Measure request rate for potential throttling issues
-	table.insert(MessagingServiceRequestTimestamps, {Time = os.clock()})
-	if #MessagingServiceRequestTimestamps > 100 then
-		table.remove(MessagingServiceRequestTimestamps, 1)
-	end
-
-	local total = #MessagingServiceRequestTimestamps
 	local avg = 0
-	
-	for _, req in MessagingServiceRequestTimestamps do
-		if os.clock() - req.Time < 60 then
-			avg += 1
+	if LastMessageTime then
+		local timeSinceLastMessage = os.clock() - LastMessageTime
+		
+		table.insert(MessagingServiceRequestTimestamps, {Time = timeSinceLastMessage})
+		if #MessagingServiceRequestTimestamps > 100 then
+			table.remove(MessagingServiceRequestTimestamps, 1)
 		end
-	end
 
-	avg /= total
+		for _, entry in MessagingServiceRequestTimestamps do
+			avg += entry.Time
+		end
+
+		avg = 60 / (avg / #MessagingServiceRequestTimestamps)
+	end
 
 	if not success then
 		utilities.GBWarn(`Failed to publish message to channel: {channel} (Req count on channel: {MessagingServiceDebugCache[channel]}, Avg. total req/min: {math.round(avg)}) with error: {errorMessage}`)
+	else
+		LastMessageTime = os.clock()
 	end
 end
 

--- a/src/Infra/Server/Public/Markers.lua
+++ b/src/Infra/Server/Public/Markers.lua
@@ -20,7 +20,6 @@ local Players = game:GetService("Players")
 
 local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module EngagementMarkers
 local PurchaseAnalytics = shared.GBMod("PurchaseAnalytics") ---@module PurchaseAnalytics
-local SessionMarkers = shared.GBMod("SessionMarkers") ---@module SessionMarkers
 
 --= Types =--
 
@@ -53,10 +52,6 @@ function Markers:SendNewPurchaseGrantedMarker(recieptInfo : {[string] : number |
     task.spawn(function()
         PurchaseAnalytics:DevProductPurchased(true, recieptInfo.PlayerId, recieptInfo.ProductId, position)
     end)
-end
-
-function Markers:SetLaunchDataFilter(filterArgs : {[string] : string | (any) -> boolean})
-    SessionMarkers:SetLaunchDataFilter(filterArgs)
 end
 
 --= Return Module =--

--- a/src/Infra/Server/Public/Markers.lua
+++ b/src/Infra/Server/Public/Markers.lua
@@ -20,6 +20,7 @@ local Players = game:GetService("Players")
 
 local EngagementMarkers = shared.GBMod("EngagementMarkers") ---@module EngagementMarkers
 local PurchaseAnalytics = shared.GBMod("PurchaseAnalytics") ---@module PurchaseAnalytics
+local SessionMarkers = shared.GBMod("SessionMarkers") ---@module SessionMarkers
 
 --= Types =--
 
@@ -52,6 +53,10 @@ function Markers:SendNewPurchaseGrantedMarker(recieptInfo : {[string] : number |
     task.spawn(function()
         PurchaseAnalytics:DevProductPurchased(true, recieptInfo.PlayerId, recieptInfo.ProductId, position)
     end)
+end
+
+function Markers:SetLaunchDataFilter(filterArgs : {[string] : string | (any) -> boolean})
+    SessionMarkers:SetLaunchDataFilter(filterArgs)
 end
 
 --= Return Module =--

--- a/src/Infra/Types.luau
+++ b/src/Infra/Types.luau
@@ -38,7 +38,6 @@ export type MarkersService = {
 	SendMarker : (self : MarkersService, marker : string, data : JSON, position : Vector3?) -> (),
 	SendPlayerMarker : (self : MarkersService, player : Player, marker : string, data : JSON, position : Vector3?) -> (),
 	SendNewPurchaseGrantedMarker : (self : MarkersService, recieptInfo : {[string] : number | string}, position : Vector3?) -> (),
-	SetLaunchDataFilter : (self : MarkersService, filterArgs : {[string] : string | (any) -> boolean}) -> (),
 }
 
 export type JobsService = {

--- a/src/Infra/Types.luau
+++ b/src/Infra/Types.luau
@@ -38,6 +38,7 @@ export type MarkersService = {
 	SendMarker : (self : MarkersService, marker : string, data : JSON, position : Vector3?) -> (),
 	SendPlayerMarker : (self : MarkersService, player : Player, marker : string, data : JSON, position : Vector3?) -> (),
 	SendNewPurchaseGrantedMarker : (self : MarkersService, recieptInfo : {[string] : number | string}, position : Vector3?) -> (),
+	SetLaunchDataFilter : (self : MarkersService, filterArgs : {[string] : string | (any) -> boolean}) -> (),
 }
 
 export type JobsService = {

--- a/src/init.lua
+++ b/src/init.lua
@@ -162,6 +162,7 @@ local function StartSDK()
 	-- Set settings
 
 	local dataCacheModule = RequireModule(GetModule("DataCache"))
+	--NOTE: All modules that use settings should await them if they are needed during init.
 	dataCacheModule:Set("Settings", table.clone(DEFAULT_SETTINGS))
 
 	-- Require all modules


### PR DESCRIPTION
Features:
- Added `referrer` argument to Login marker.
- Updated README.md
- Added support to experiments system for filtered experiments, including:
  - Fetching and adding gameserver & player metadata to assignment requests
  - Reassigning gameservers & players who weren't previously eligible for any available experiments when new experiments become available

Fixes:
- Ban, Unban, & Kick jobs
- Custom API URLs apply immediately on startup.
- `friendPlaytimePercent` no longer becomes >1
- Server IDs on retried markers should now be correct

Changes:
- Removed `JoinedUser` default marker
- Adjusted MessagingService logging
- Changed longest maximum time that experiment assignment can hold up initial configuration loading from 5 to 10 seconds to miss less client-fetched metadata needed for assignment in cases with bad performance
- When future-scheduled experiments are about to begin, each gameserver now performs a single bulk HTTP request to fetch information about the latest experiments